### PR TITLE
fix: Resolve backend pod crash, 404 on localhost, and helm template bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Prepend with the name of the service: `openmrs-backend`, `openmrs-frontend`, `op
 | `openmrs-backend.monitoring.enabled`                             | Enable monitoring (Grafana, Loki, Alloy)                                                                               | `"false"`                                                 |
 | `openmrs-backend.grafana.adminPassword`                          | Grafana admin password                                                                                                 | `"Admin123"`                                              |
 | `openmrs-backend.grafana.ingress.enabled`                        | Enable ingress for Grafana                                                                                             | `"true"`                                                  |
-| `openmrs-backend.grafana.ingress.hosts`                          | Hosts for Grafana ingress                                                                                              | `["localhost"]`                                           |
+| `openmrs-backend.grafana.ingress.hosts`                          | Hosts for Grafana ingress                                                                                              | `["grafana.local"]`                                       |
 
 See [MariaDB](https://github.com/bitnami/charts/blob/main/bitnami/mariadb/README.md) helm chart for other MariaDB parameters.
 

--- a/helm/kind-openmrs-min.yaml
+++ b/helm/kind-openmrs-min.yaml
@@ -1,6 +1,6 @@
 global:
   defaultStorageClass: standard
-  defaultIngessClass: nginx
+  defaultIngressClass: nginx
 mariadb:
   auth:
     rootPassword: Root123

--- a/helm/openmrs-backend/templates/_helpers.tpl
+++ b/helm/openmrs-backend/templates/_helpers.tpl
@@ -80,7 +80,7 @@ Create the url for the elastic search
 {{- define "openmrs-elasticsearch.url" -}}
 {{- $releaseNameSpace := .Release.Namespace -}}
 {{- $clusterDomain := "svc.cluster.local" }}
-{{- $port := default "9200"  quote .Values.elasticsearch.service.ports.restAPI }}
+{{- $port := default "9200" (.Values.elasticsearch.service.ports.restAPI | toString) }}
 {{- $fullurl := printf "%s%s.%s.%s:%s" "http://" (include "elasticsearch.serviceName" .) $releaseNameSpace $clusterDomain $port }}
 {{- quote $fullurl }}
 {{- end }}
@@ -104,7 +104,7 @@ Create the url for the minio
 {{- define "openmrs-minio.url" -}}
 {{- $releaseNameSpace := .Release.Namespace -}}
 {{- $clusterDomain := "svc.cluster.local" }}
-{{- $port := default "9000"  quote .Values.minio.containerPorts.api }}
+{{- $port := default "9000" (.Values.minio.containerPorts.api | toString) }}
 {{- $fullurl := printf "%s%s.%s.%s:%s" "http://" (include "minio.serviceName" .) $releaseNameSpace $clusterDomain $port }}
 {{- quote $fullurl }}
 {{- end }}

--- a/helm/openmrs-backend/templates/configmap.yaml
+++ b/helm/openmrs-backend/templates/configmap.yaml
@@ -30,7 +30,7 @@ data:
   OMRS_SEARCH_ES_URIS: {{ include "openmrs-elasticsearch.url" . }}
   {{- else if .Values.elasticsearch.uris }}
   OMRS_SEARCH: "elasticsearch"
-  OMRS_SEARCH_ES_URIS: .Values.elasticsearch.uris
+  OMRS_SEARCH_ES_URIS: {{ .Values.elasticsearch.uris | quote }}
   {{- end }}
   {{- if .Values.minio.enabled }}
   storage.type: "s3"

--- a/helm/openmrs-backend/templates/statefulset.yaml
+++ b/helm/openmrs-backend/templates/statefulset.yaml
@@ -36,8 +36,9 @@ spec:
         - name: workdir
           emptyDir: { }
 
-      {{ if or (.Values.galera.enabled) (.Values.mariadb.enabled) }}
+      {{- if or .Values.galera.enabled .Values.mariadb.enabled .Values.elasticsearch.enabled }}
       initContainers:
+      {{- if or .Values.galera.enabled .Values.mariadb.enabled }}
         - name: resolve-mariadb-hosts
           image: bitnamilegacy/kubectl:1.33.4
           envFrom:
@@ -82,7 +83,31 @@ spec:
           volumeMounts:
             - name: workdir
               mountPath: /work-dir
-      {{ end }}
+      {{- end }}
+      {{- if .Values.elasticsearch.enabled }}
+        - name: wait-for-elasticsearch
+          image: bitnamilegacy/kubectl:1.33.4
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for Elasticsearch statefulset to be ready..."
+              ES_STATEFULSET="{{ .Release.Name }}-elasticsearch-master"
+              MAX_RETRIES=60
+              RETRY_INTERVAL=5
+              i=0
+              until [ "$(kubectl get statefulset $ES_STATEFULSET -n {{ .Release.Namespace }} -o jsonpath='{.status.readyReplicas}')" -gt 0 ] 2>/dev/null; do
+                i=$((i + 1))
+                if [ $i -ge $MAX_RETRIES ]; then
+                  echo "Timeout waiting for Elasticsearch after $((MAX_RETRIES * RETRY_INTERVAL)) seconds."
+                  exit 1
+                fi
+                echo "Elasticsearch not ready yet (attempt $i/$MAX_RETRIES), retrying in ${RETRY_INTERVAL}s..."
+                sleep $RETRY_INTERVAL
+              done
+              echo "Elasticsearch is ready! ($(kubectl get statefulset $ES_STATEFULSET -n {{ .Release.Namespace }} -o jsonpath='{.status.readyReplicas}') replicas ready)"
+      {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/helm/openmrs-backend/values.yaml
+++ b/helm/openmrs-backend/values.yaml
@@ -270,7 +270,7 @@ grafana:
   adminPassword: "Admin123"
   grafana.ini: # Needed for serving from path
     server:
-      domain: localhost
+      domain: grafana.local
       root_url: "%(protocol)s://%(domain)s/grafana"
       serve_from_sub_path: true
     dashboards:
@@ -283,7 +283,7 @@ grafana:
   ingress:
     enabled: true
     hosts:
-      - "localhost"
+      - "grafana.local"
     path: '/grafana'
   datasources:
     datasources.yaml:


### PR DESCRIPTION
### 1. Localhost 404: Grafana ingress shadowing OpenMRS
When accessing `http://localhost:8080/openmrs/`, nginx returned **404 Not Found**. The Grafana ingress had `host: localhost`, which created an nginx `server_name localhost` block that shadowed the OpenMRS catch-all ingress (`server_name _;`). Requests for `/openmrs/` hit the Grafana block which only knows `/grafana`, producing a 404.

**Fix:** Changed Grafana's ingress host to `grafana.local` (matching its `server.domain`). The OpenMRS catch-all now correctly handles `localhost` requests.

### 2. Backend pod crash loop: Hibernate Search connection failure
The backend pod would start, Hibernate Search would immediately try connecting to Elasticsearch at `http://openmrs-elasticsearch:9200`, but the ES cluster (3 master replicas) was still forming quorum. Spring's context refresh failed with a `BeanCreationException`, the webapp undeployed, and the pod entered a crash/restart loop.

**Fix:** Added a `wait-for-elasticsearch` initContainer that uses `kubectl get statefulset` to block pod startup until the ES master statefulset reports ready replicas (up to 5 min timeout). This ensures ES is available before OpenMRS initializes Hibernate Search.

### 3. ConfigMap rendered literal text instead of value
When using external ES (`elasticsearch.enabled: false, elasticsearch.uris: ...`), the ConfigMap contained the literal string `.Values.elasticsearch.uris` instead of the actual URI value, because it was written as a raw YAML string instead of a Helm template expression.

**Fix:** Wrapped the value with `{{ ... | quote }}` so Helm evaluates it properly.

### 4. Malformed ES/MinIO URLs: misplaced `quote` function
The `_helpers.tpl` URL templates used `quote .Values.elasticsearch.service.ports.restAPI`, which wraps the port number in literal double-quote characters. The rendered URL became `http://service.namespace.svc.cluster.local:"9200"` — syntactically invalid.

**Fix:** Replaced `quote ...` with `(.Values... | toString)` to produce a clean string without embedded quotes.

### 5. Typo in kind config
`defaultIngessClass` was missing an 'r', which would cause it to be ignored by nginx.

**Fix:** Corrected to `defaultIngressClass`.