### PR TITLE
Update InfraScan action to version 1.0.6

### DIFF
--- a/.github/workflows/infrascan.yml
+++ b/.github/workflows/infrascan.yml
@@ -17,7 +17,7 @@ jobs:
           chmod 777 infrascan-reports
 
       - name: Run InfraScan
-        uses: soldevelo/infrascan@v1.0.5
+        uses: soldevelo/infrascan@v1.0.6
         with:
           scanner: comprehensive
           format: html


### PR DESCRIPTION
This update bumps the InfraScan GitHub Action to version `1.0.6`.

The change fixes an issue related to the GitHub Actions workflow execution by using the latest InfraScan release, which includes compatibility and stability improvements for the CI pipeline.
