### PR TITLE
TRUNK-6627: Replace archived Bitnami MinIO with first-party SeaweedFS

### DIFF
--- a/.github/workflows/helm-build.yaml
+++ b/.github/workflows/helm-build.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.14.2
+          version: v3.17.4
 
       - name: Add Helm Repositories
         run: |

--- a/README.md
+++ b/README.md
@@ -172,6 +172,15 @@ Prepend with the name of the service: `openmrs-backend`, `openmrs-frontend`, `tr
 | `openmrs-backend.grafana.adminPassword`                          | Grafana admin password                                                                                                 | `"Admin123"`                                              |
 | `openmrs-backend.grafana.ingress.enabled`                        | Enable ingress for Grafana                                                                                             | `"true"`                                                  |
 | `openmrs-backend.grafana.ingress.hosts`                          | Hosts for Grafana ingress                                                                                              | `["grafana.local"]`                                       |
+| `openmrs-backend.seaweedfs.enabled`                        | Deploy SeaweedFS S3-compatible object storage (replaces MinIO)                                                    | `"false"`                                                 |
+| `openmrs-backend.seaweedfs.master.replicas`                | Number of SeaweedFS master nodes for Raft consensus                                                               | `3`                                                       |
+| `openmrs-backend.seaweedfs.volume.replicas`                | Number of SeaweedFS volume servers (data storage pods); one per worker node recommended                           | `3`                                                       |
+| `openmrs-backend.seaweedfs.volume.dataDirs[0].size`        | Persistent volume size per volume server pod                                                                      | `"8Gi"`                                                   |
+| `openmrs-backend.seaweedfs.filer.replicas`                 | Number of SeaweedFS filer replicas for metadata store (3+ recommended for HA)                                     | `3`                                                       |
+| `openmrs-backend.seaweedfs.s3.replicas`                    | Number of S3 API gateway replicas (stateless)                                                                     | `2`                                                       |
+| `openmrs-backend.seaweedfs.s3.enableAuth`                  | Enable S3 credential authentication                                                                               | `"true"`                                                  |
+| `openmrs-backend.seaweedfs.s3.credentials.admin.accessKey` | S3 access key (must match backend's `storage.s3.accessKeyId`)                                                     | `"openmrs"`                                               |
+| `openmrs-backend.seaweedfs.s3.credentials.admin.secretKey` | S3 secret key (must match backend's `storage.s3.secretAccessKey`)                                                 | `"OpenMRS123"`                                            |
 
 See [MariaDB Operator](https://github.com/mariadb-operator/mariadb-operator) for MariaDB CRD parameters.
 
@@ -181,6 +190,51 @@ before enabling Elasticsearch — see the Prerequisites section below.
 
 See [Grafana](https://github.com/grafana-community/helm-charts/blob/main/charts/grafana/README.md), [Loki](https://github.com/grafana/loki/blob/main/production/helm/loki/README.md) and [Alloy](https://github.com/grafana/alloy/blob/main/operations/helm/charts/alloy/README.md) helm charts for other Grafana parameters.
 
+#### Prerequisites: SeaweedFS (S3-compatible object storage)
+
+No separate operator installation is required. SeaweedFS is included as a
+Helm subchart dependency of `openmrs-backend`. When
+`openmrs-backend.seaweedfs.enabled=true`, the chart deploys:
+
+| Component | Pods | Purpose |
+|---|---|---|
+| Master | 3 | Raft-based cluster coordination |
+| Volume server | 3 | Persistent data storage with PVCs (one per worker node recommended) |
+| Filer | 3 | Metadata store required by the S3 gateway (uses MariaDB as backend for easy backup) |
+| S3 gateway | 2 | Stateless S3 API endpoint at `<release>-seaweedfs-s3:8333` (depends on filer) |
+
+Credentials are automatically configured via `s3.credentials.admin` values
+and injected into the backend's Secret as `storage.s3.accessKeyId` and
+`storage.s3.secretAccessKey`. See the backend parameters table above for
+configuration options.
+
+##### SeaweedFS Filer: MariaDB backend
+
+The filer uses MariaDB as its metadata store. The subchart's filer StatefulSet template
+hardcodes `WEED_MYSQL_USERNAME` and `WEED_MYSQL_PASSWORD` referencing the Secret
+`{release}-seaweedfs-db-secret` with keys `user` and `password` (both `optional: true`).
+The subchart creates this Secret automatically as a pre-install hook (with placeholder
+credentials). The chart overrides these via two mechanisms (env vars take precedence by
+appearing after the hardcoded entries):
+
+1. `filer.extraEnvironmentVars.WEED_MYSQL_USERNAME` — plain value (username is not sensitive)
+2. `filer.secretExtraEnvironmentVars.WEED_MYSQL_PASSWORD` — references the MariaDB
+   secret `{fullname}-mariadb-secret` key `user-password`, avoiding the password in
+   the StatefulSet YAML
+
+> The secret name in `secretExtraEnvironmentVars` is a hardcoded string because the
+> subchart does not process it through `tpl`. The default `{fullname}-mariadb-secret`
+> assumes `openmrs-backend` as the fullname. If you override `nameOverride` or
+> `fullnameOverride`, update this value to match.
+
+The chart also creates a pre-install hook Job that creates the `filemeta` table
+before the filer starts. This table is required by the filer's MariaDB store and
+the filer will crash with a fatal error if it is missing.
+
+The chart creates a pre-install hook Job that creates the `filemeta` table before the filer starts — the filer requires this table to exist and will crash with a fatal error if it is missing.
+
+See [SeaweedFS documentation](https://github.com/seaweedfs/seaweedfs/wiki)
+for full details.
 ### Terraform and AWS
 
 #### Setting up terraform and AWS

--- a/helm/kind-openmrs.yaml
+++ b/helm/kind-openmrs.yaml
@@ -52,15 +52,46 @@ openmrs-backend:
                     memory: "2Gi"
                     ephemeral-storage: 10Gi
 
-  minio:
+  seaweedfs:
     enabled: true
-    auth:
-      rootPassword: Root1234
-    provisioning:
-      users:
-        - username: openmrs
-          password: OpenMRS123
-          policies: ["readwrite"]
+    global:
+      seaweedfs:
+        enableSecurity: false
+    master:
+      replicas: 3
+    volume:
+      enabled: true
+      replicas: 3
+      dataDirs:
+        - name: data
+          type: "persistentVolumeClaim"
+          storageClass: "standard"
+          size: "8Gi"
+          maxVolumes: 0
+    filer:
+      enabled: true
+      replicas: 3
+      extraEnvironmentVars:
+        WEED_MYSQL_ENABLED: "true"
+        WEED_MYSQL_HOSTNAME: "{{ .Release.Name }}-mariadb"
+        WEED_MYSQL_DATABASE: "openmrs"
+        WEED_MYSQL_USERNAME: "openmrs"
+        WEED_LEVELDB2_ENABLED: "false"
+      secretExtraEnvironmentVars:
+        WEED_MYSQL_PASSWORD:
+          secretKeyRef:
+            name: "openmrs-backend-mariadb-secret"
+            key: user-password
+    s3:
+      enabled: true
+      replicas: 2
+      enableAuth: true
+      credentials:
+        admin:
+          accessKey: "openmrs"
+          secretKey: "OpenMRS123"
+      createBuckets:
+        - name: openmrs
 openmrs-frontend:
   image:
     repository: openmrs/openmrs-reference-application-3-frontend

--- a/helm/openmrs-backend/templates/_helpers.tpl
+++ b/helm/openmrs-backend/templates/_helpers.tpl
@@ -84,26 +84,6 @@ Full internal cluster URL for the ECK-managed Elasticsearch HTTP service.
     $port | quote -}}
 {{- end }}
 
-{{/*
-Get the service name of minio created by bitmani elastic helm chart
-*/}}
-{{- define "minio.serviceName" -}}
-{{- $name := "minio" -}}
-{{- $releaseName := regexReplaceAll "(-?[^a-z\\d\\-])+-?" (lower .Release.Name) "-" -}}
-{{- if contains $name $releaseName -}}
-{{- $releaseName | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" $releaseName $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end }}
-
-{{/*
-Create the url for the minio
-*/}}
-{{- define "openmrs-minio.url" -}}
-{{- $releaseNameSpace := .Release.Namespace -}}
-{{- $clusterDomain := "svc.cluster.local" }}
-{{- $port := default "9000" (.Values.minio.containerPorts.api | toString) }}
-{{- $fullurl := printf "%s%s.%s.%s:%s" "http://" (include "minio.serviceName" .) $releaseNameSpace $clusterDomain $port }}
-{{- quote $fullurl }}
+{{- define "openmrs-seaweedfs.s3url" -}}
+{{- printf "http://%s-seaweedfs-s3.%s.svc.cluster.local:8333" .Release.Name .Release.Namespace }}
 {{- end }}

--- a/helm/openmrs-backend/templates/configmap.yaml
+++ b/helm/openmrs-backend/templates/configmap.yaml
@@ -39,10 +39,10 @@ data:
   OMRS_SEARCH_ES_URIS: {{ .Values.elasticsearch.uris | quote }}
   OMRS_EXTRA_HIBERNATE_SEARCH_BACKEND_SSL_VERIFICATION__MODE: "none"
   {{- end }}
-  {{- if .Values.minio.enabled }}
+  {{- if .Values.seaweedfs.enabled }}
   storage.type: "s3"
-  storage.s3.region: "us-east-1"
-  storage.s3.endpoint: {{ include "openmrs-minio.url" . }}
+  storage.s3.region: "us-east-2"
+  storage.s3.endpoint: {{ include "openmrs-seaweedfs.s3url" . }}
   storage.s3.forcePathStyle: "true"
   {{- end }}
   {{- if .Values.infinispan.clustered }}

--- a/helm/openmrs-backend/templates/mariadb-init-filemeta.yaml
+++ b/helm/openmrs-backend/templates/mariadb-init-filemeta.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.seaweedfs.enabled .Values.seaweedfs.filer.enabled }}
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: SqlJob
+metadata:
+  name: {{ .Release.Name }}-seaweedfs-filemeta
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openmrs-backend.labels" . | nindent 4 }}
+spec:
+  mariaDbRef:
+    name: {{ .Release.Name }}-mariadb
+  username: {{ .Values.mariadb.auth.username | default "openmrs" | quote }}
+  passwordSecretKeyRef:
+    name: {{ include "openmrs-backend.fullname" . }}-mariadb-secret
+    key: user-password
+  database: {{ .Values.mariadb.auth.database | default "openmrs" | quote }}
+  sql: |
+    CREATE TABLE IF NOT EXISTS `filemeta` (
+      `dirhash`   BIGINT NOT NULL,
+      `name`      VARCHAR(766) NOT NULL,
+      `directory` TEXT NOT NULL,
+      `meta`      LONGBLOB DEFAULT NULL,
+      PRIMARY KEY (`dirhash`, `name`)
+    ) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+  backoffLimit: 5
+  restartPolicy: OnFailure
+{{- end }}

--- a/helm/openmrs-backend/templates/secret.yaml
+++ b/helm/openmrs-backend/templates/secret.yaml
@@ -19,9 +19,7 @@ stringData:
   {{- else if .Values.elasticsearch.enabled }}
   OMRS_EXTRA_HIBERNATE_SEARCH_BACKEND_USERNAME: "elastic"
   {{- end }}
-  {{- if .Values.minio.enabled }}
-  {{- with (first .Values.minio.provisioning.users)}}
-  storage.s3.accessKeyId: {{ .username | quote }}
-  storage.s3.secretAccessKey: {{ .password | quote }}
-  {{- end }}
+  {{- if .Values.seaweedfs.enabled }}
+  storage.s3.accessKeyId: {{ .Values.seaweedfs.s3.credentials.admin.accessKey | quote }}
+  storage.s3.secretAccessKey: {{ .Values.seaweedfs.s3.credentials.admin.secretKey | quote }}
   {{- end }}

--- a/helm/openmrs-backend/values.yaml
+++ b/helm/openmrs-backend/values.yaml
@@ -91,38 +91,40 @@ elasticsearch-eck:
           requests:
             storage: 10Gi
 
-minio:
-  enabled: false
-  image:
-    repository: bitnamilegacy/minio
-    tag: 2025.7.23
-  clientImage:
-    repository: bitnamilegacy/minio-client
-  defaultInitContainers:
-    volumePermissions:
-      image:
-        repository: bitnamilegacy/os-shell
-  containerPorts:
-    api: 9000
-    console: 9001
-  console:
-    image:
-      repository: bitnamilegacy/minio-object-browser
-  mode: distributed
-  auth:
-    rootPassword: Root1234
-  statefulset:
-    replicaCount: 4
-    zones: 1
-    drivesPerNode: 1
-  provisioning:
+seaweedfs:
+  master:
+    replicas: 3
+  volume:
     enabled: true
-    buckets:
-      - name: openmrs
-    users:
-      - username: openmrs
-        password: OpenMRS123
-        policies: ["readwrite"]
+    replicas: 3
+    dataDirs:
+      - name: data
+        type: "persistentVolumeClaim"
+        storageClass: "standard"
+        size: "8Gi"
+        maxVolumes: 0
+  filer:
+    enabled: true
+    replicas: 3
+    extraEnvironmentVars:
+      WEED_MYSQL_ENABLED: "true"
+      WEED_MYSQL_HOSTNAME: "{{ .Release.Name }}-mariadb"
+      WEED_MYSQL_DATABASE: "openmrs"
+      WEED_MYSQL_USERNAME: "openmrs"
+      WEED_LEVELDB2_ENABLED: "false"
+    secretExtraEnvironmentVars:
+      WEED_MYSQL_PASSWORD:
+        secretKeyRef:
+          name: "openmrs-backend-mariadb-secret"
+          key: user-password
+  s3:
+    enabled: true
+    replicas: 2
+    enableAuth: true
+    credentials:
+      admin:
+        accessKey: "openmrs"
+        secretKey: "OpenMRS123"
 
 imagePullSecrets: []
 


### PR DESCRIPTION
This PR replaces the unmaintained Bitnami MinIO Helm subchart with the official SeaweedFS chart as a dependency of the openmrs-backend subchart.


JIRA Ticket: https://openmrs.atlassian.net/browse/TRUNK-6627

