### PR TITLE
TRUNK:6632 Add helm template rendering validation to helm-build workflow

### DIFF
--- a/.github/workflows/helm-build.yaml
+++ b/.github/workflows/helm-build.yaml
@@ -23,11 +23,18 @@ jobs:
       - name: Add Helm Repositories
         run: |
           helm repo add grafana https://grafana.github.io/helm-charts
+          helm repo add elastic https://helm.elastic.co
+          helm repo update
 
       - name: Lint Subcharts
         run: |
           helm lint helm/openmrs-backend
           helm lint helm/openmrs-frontend
+
+      - name: Update Subchart Dependencies
+        run: |
+          helm dependency update helm/openmrs-backend
+          helm dependency update helm/openmrs-frontend
 
       - name: Update Dependencies
         run: helm dependency update helm/openmrs
@@ -37,3 +44,18 @@ jobs:
 
       - name: Package Chart
         run: helm package helm/openmrs
+
+      - name: Validate Rendering (default values)
+        run: helm template helm/openmrs --generate-name
+
+      - name: Validate Rendering (full-featured)
+        run: |
+          helm template helm/openmrs --generate-name \
+            --values helm/kind-openmrs.yaml
+
+      - name: Validate Rendering (minimal, no optional features)
+        run: |
+          helm template helm/openmrs --generate-name \
+            --set openmrs-backend.monitoring.enabled=false \
+            --set openmrs-backend.elasticsearch.enabled=false \
+            --set openmrs-backend.minio.enabled=false


### PR DESCRIPTION

Add three helm template rendering checks after packaging to prevent rendering regressions from going undetected until deployment:

- Default values (all optional features off)
- Full-featured (monitoring + Elasticsearch + MinIO enabled)
- Minimal (all optional features explicitly disabled)

Also add the elastic Helm repo and update subchart dependencies before template validation to ensure all deps (minio OCI, grafana,loki, alloy, ECK) are available for rendering.

JIRA TICKET: https://openmrs.atlassian.net/browse/TRUNK-6632