### PR TITLE
TRUNK-6652: Add openmrs-tenant chart for multi-tenancy

### DIFF
--- a/.github/workflows/helm-build.yaml
+++ b/.github/workflows/helm-build.yaml
@@ -104,3 +104,15 @@ jobs:
           fail_if_renders openmrs-backend.seaweedfs.s3.enableAuth=true
           fail_if_renders openmrs-backend.seaweedfs.admin.ingress.enabled=true
           fail_if_renders openmrs-backend.seaweedfs.admin.enabled=true
+
+      - name: Lint and Render Tenant Chart
+        run: |
+          TENANT_VALUES="--set tenant.name=ci \
+            --set backend.db.hostname=mariadb.example.svc.cluster.local \
+            --set backend.db.database=openmrs_ci \
+            --set backend.db.user=ci_user \
+            --set backend.db.password=ci-pass"
+          helm lint helm/openmrs-tenant $TENANT_VALUES
+          helm template helm/openmrs-tenant --generate-name $TENANT_VALUES
+          helm template helm/openmrs-tenant --generate-name $TENANT_VALUES \
+            --set backend.infinispan.clustered=true

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ separate ConfigMaps, Secrets, Services, and labelled pods.
 #### Prerequisites
 
 - Primary OpenMRS stack deployed and running (steps 1–4 above)
-- MariaDB accessible from tenant namespace (default DNS: `openmrs-mariadb.openmrs.svc.cluster.local`)
+- MariaDB accessible from tenant namespace (default DNS: `<primary-release>-mariadb.<primary-namespace>.svc.cluster.local`, e.g. `openmrs-mariadb.openmrs.svc.cluster.local`)
 - A database and user created for the tenant:
 
 ```bash
@@ -126,7 +126,7 @@ helm install <tenant> helm/openmrs-tenant \
   -n tenant-<tenant> --create-namespace \
   --set tenant.name=<tenant> \
   --set global.defaultStorageClass=standard \
-  --set backend.db.hostname=openmrs-mariadb.openmrs.svc.cluster.local \
+  --set backend.db.hostname=<primary-release>-mariadb.<primary-namespace>.svc.cluster.local \
   --set backend.db.database=openmrs_<tenant> \
   --set backend.db.user=<tenant>_user \
   --set backend.db.password=<password>
@@ -183,11 +183,20 @@ kubectl port-forward -n tenant-<tenant> svc/<tenant>-frontend 8081:80
 | `backend.db.database` | Database name | **required** |
 | `backend.db.user` | Database user | **required** |
 | `backend.db.password` | Database password | **required** |
-| `backend.storage.size` | PVC size for /openmrs/data | `8Gi` |
-| `backend.storage.storageClass` | Backend PVC StorageClass (defaults to `global.defaultStorageClass`) | `""` |
+| `backend.persistence.size` | PVC size for /openmrs/data | `8Gi` |
+| `backend.persistence.storageClass` | Backend PVC StorageClass (defaults to `global.defaultStorageClass`) | `""` |
+| `backend.storage.type` | Storage type for patient documents | `"local"` |
+| `frontend.apiUrl` | Frontend API URL for SPA backend calls | `"http://localhost:8080/openmrs"` |
 | `frontend.image.repository` | Frontend image | `openmrs/openmrs-reference-application-3-frontend` |
 | `frontend.image.tag` | Frontend image tag | `nightly-core-2.8` |
 | `frontend.replicaCount` | Frontend Deployment replicas | `1` |
+
+> **Note on `storage.type: "local"`:** When `backend.storage.type` is `"local"` (the default),
+> each StatefulSet pod mounts its own dedicated PVC. If `backend.replicaCount > 1`,
+> patient documents uploaded to pod-0 will not be visible on pod-1. For multi-replica
+> setups, configure external shared storage (e.g. S3-compatible SeaweedFS) by setting
+> `backend.storage.type` and the corresponding S3 credentials. SeaweedFS integration
+> is currently available in the parent `openmrs` chart; tenant chart support is planned.
 
 ### Alternative: install from Helm registry
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ helm install coast helm/openmrs-tenant \
   --set backend.db.password=CoastPass123
 ```
 
+> **Note:** Resource names (`<tenant>-backend`, `<tenant>-frontend`) derive from the
+> **release name** — the first argument to `helm install` — not from `tenant.name`.
+> `tenant.name` only sets the `app.kubernetes.io/tenant` label. Keep the release name
+> and `tenant.name` the same (as shown above) so the commands below resolve correctly.
+
 #### Verification
 
 ```bash
@@ -162,8 +167,12 @@ kubectl port-forward -n tenant-<tenant> svc/<tenant>-frontend 8081:80
 ```
 
 > **Note on routing:** Currently each tenant's backend and frontend are separate
-> services in their own namespace. You access them via `kubectl port-forward`
-> as shown above. In the future, tenant-specific Gateway API HTTPRoute resources
+> services in their own namespace. The backend API is reachable via `kubectl
+> port-forward` as shown above. The **frontend SPA UI is not fully usable over
+> port-forward yet** — the app shell requests its assets under `SPA_PATH`
+> (`/openmrs/spa`), which needs a gateway rewrite (stripping the prefix before
+> nginx) that port-forward cannot provide. In the future, tenant-specific
+> Gateway API HTTPRoute resources
 > will be added to place the frontend and backend behind the same hostname
 > (e.g. `<tenant>.example.com`) with path-based routing — `/openmrs/spa` to the
 > frontend and `/openmrs` to the backend — eliminating the need for
@@ -173,7 +182,7 @@ kubectl port-forward -n tenant-<tenant> svc/<tenant>-frontend 8081:80
 
 | Name | Description | Default |
 |------|-------------|---------|
-| `tenant.name` | Tenant identifier (used as resource prefix) | **required** |
+| `tenant.name` | Tenant identifier (sets the `app.kubernetes.io/tenant` label on every resource) | **required** |
 | `global.defaultStorageClass` | Default StorageClass for PVCs | `""` |
 | `backend.image.repository` | Backend image | `openmrs/openmrs-reference-application-3-backend` |
 | `backend.image.tag` | Backend image tag | `nightly-core-2.8` |
@@ -187,6 +196,9 @@ kubectl port-forward -n tenant-<tenant> svc/<tenant>-frontend 8081:80
 | `backend.persistence.storageClass` | Backend PVC StorageClass (defaults to `global.defaultStorageClass`) | `""` |
 | `backend.storage.type` | Storage type for patient documents | `"local"` |
 | `frontend.apiUrl` | Frontend API URL for SPA backend calls | `"http://localhost:8080/openmrs"` |
+| `frontend.spaPath` | URL path the SPA is served from (`SPA_PATH`) | `"/openmrs/spa"` |
+| `frontend.defaultLocale` | Default UI locale (`SPA_DEFAULT_LOCALE`) | `"en"` |
+| `frontend.configUrls` | Distro config JSON URLs (`SPA_CONFIG_URLS`); omitted when empty | `""` |
 | `frontend.image.repository` | Frontend image | `openmrs/openmrs-reference-application-3-frontend` |
 | `frontend.image.tag` | Frontend image tag | `nightly-core-2.8` |
 | `frontend.replicaCount` | Frontend Deployment replicas | `1` |

--- a/README.md
+++ b/README.md
@@ -98,6 +98,97 @@ To disable monitoring (Grafana, Loki, Alloy), set `monitoring.enabled=false` in 
 | `SKIP_OPERATORS=true` | `false` | Skip `openmrs-operator` chart install |
 | `SKIP_OPENMRS=true` | `false` | Skip OpenMRS deployment (exit after step 3) |
 
+### 6. Deploy additional tenants (multi-tenancy)
+
+The `helm/openmrs-tenant` chart deploys an isolated OpenMRS tenant (backend + frontend)
+that shares the primary cluster's MariaDB. Each tenant gets its own namespace with
+separate ConfigMaps, Secrets, Services, and labelled pods.
+
+#### Prerequisites
+
+- Primary OpenMRS stack deployed and running (steps 1–4 above)
+- MariaDB accessible from tenant namespace (default DNS: `openmrs-mariadb.openmrs.svc.cluster.local`)
+- A database and user created for the tenant:
+
+```bash
+kubectl exec -n openmrs svc/openmrs-mariadb -- mysql -u root -pRoot123 -e "
+  CREATE DATABASE IF NOT EXISTS openmrs_<tenant> CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+  CREATE USER IF NOT EXISTS '<tenant>_user'@'%' IDENTIFIED BY '<password>';
+  GRANT ALL PRIVILEGES ON openmrs_<tenant>.* TO '<tenant>_user'@'%';
+  FLUSH PRIVILEGES;
+"
+```
+
+#### Install a tenant
+
+```bash
+helm install <tenant> helm/openmrs-tenant \
+  -n tenant-<tenant> --create-namespace \
+  --set tenant.name=<tenant> \
+  --set global.defaultStorageClass=standard \
+  --set backend.db.hostname=openmrs-mariadb.openmrs.svc.cluster.local \
+  --set backend.db.database=openmrs_<tenant> \
+  --set backend.db.user=<tenant>_user \
+  --set backend.db.password=<password>
+```
+
+Example for a tenant named `coast`:
+
+```bash
+helm install coast helm/openmrs-tenant \
+  -n tenant-coast --create-namespace \
+  --set tenant.name=coast \
+  --set global.defaultStorageClass=standard \
+  --set backend.db.hostname=openmrs-mariadb.openmrs.svc.cluster.local \
+  --set backend.db.database=openmrs_coast \
+  --set backend.db.user=coast_user \
+  --set backend.db.password=CoastPass123
+```
+
+#### Verification
+
+```bash
+# Check pods with tenant label
+kubectl get pods -n tenant-<tenant> -L app.kubernetes.io/tenant
+
+# Wait for ready
+kubectl wait --for=condition=ready pod -n tenant-<tenant> --all --timeout=600s
+
+# Port-forward to backend (API)
+kubectl port-forward -n tenant-<tenant> svc/<tenant>-backend 8080:8080
+
+# Port-forward to frontend (SPA)
+kubectl port-forward -n tenant-<tenant> svc/<tenant>-frontend 8081:80
+```
+
+> **Note on routing:** Currently each tenant's backend and frontend are separate
+> services in their own namespace. You access them via `kubectl port-forward`
+> as shown above. In the future, tenant-specific Gateway API HTTPRoute resources
+> will be added to place the frontend and backend behind the same hostname
+> (e.g. `<tenant>.example.com`) with path-based routing — `/openmrs/spa` to the
+> frontend and `/openmrs` to the backend — eliminating the need for
+> port-forwarding, just like the primary OpenMRS stack.
+
+#### Tenant chart parameters
+
+| Name | Description | Default |
+|------|-------------|---------|
+| `tenant.name` | Tenant identifier (used as resource prefix) | **required** |
+| `global.defaultStorageClass` | Default StorageClass for PVCs | `""` |
+| `backend.image.repository` | Backend image | `openmrs/openmrs-reference-application-3-backend` |
+| `backend.image.tag` | Backend image tag | `nightly-core-2.8` |
+| `backend.replicaCount` | Backend StatefulSet replicas | `1` |
+| `backend.db.hostname` | MariaDB hostname | **required** |
+| `backend.db.port` | MariaDB port | `3306` |
+| `backend.db.database` | Database name | **required** |
+| `backend.db.user` | Database user | **required** |
+| `backend.db.password` | Database password | **required** |
+| `backend.storage.size` | PVC size for /openmrs/data | `8Gi` |
+| `backend.storage.storageClass` | Backend PVC StorageClass (defaults to `global.defaultStorageClass`) | `""` |
+| `frontend.image.repository` | Frontend image | `openmrs/openmrs-reference-application-3-frontend` |
+| `frontend.image.tag` | Frontend image tag | `nightly-core-2.8` |
+| `frontend.replicaCount` | Frontend Deployment replicas | `1` |
+
 ### Alternative: install from Helm registry
 
       helm repo add openmrs https://openmrs.github.io/openmrs-contrib-cluster/

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ kubectl port-forward -n tenant-<tenant> svc/<tenant>-frontend 8081:80
 | `tenant.name` | Tenant identifier (sets the `app.kubernetes.io/tenant` label on every resource) | **required** |
 | `global.defaultStorageClass` | Default StorageClass for PVCs | `""` |
 | `backend.image.repository` | Backend image | `openmrs/openmrs-reference-application-3-backend` |
-| `backend.image.tag` | Backend image tag | `nightly-core-2.8` |
+| `backend.image.tag` | Backend image tag | `3.7.x-no-demo` |
 | `backend.replicaCount` | Backend StatefulSet replicas | `1` |
 | `backend.db.hostname` | MariaDB hostname | **required** |
 | `backend.db.port` | MariaDB port | `3306` |
@@ -200,7 +200,7 @@ kubectl port-forward -n tenant-<tenant> svc/<tenant>-frontend 8081:80
 | `frontend.defaultLocale` | Default UI locale (`SPA_DEFAULT_LOCALE`) | `"en"` |
 | `frontend.configUrls` | Distro config JSON URLs (`SPA_CONFIG_URLS`); omitted when empty | `""` |
 | `frontend.image.repository` | Frontend image | `openmrs/openmrs-reference-application-3-frontend` |
-| `frontend.image.tag` | Frontend image tag | `nightly-core-2.8` |
+| `frontend.image.tag` | Frontend image tag | `3.7.x` |
 | `frontend.replicaCount` | Frontend Deployment replicas | `1` |
 
 > **Note on `storage.type: "local"`:** When `backend.storage.type` is `"local"` (the default),

--- a/helm/openmrs-tenant/.helmignore
+++ b/helm/openmrs-tenant/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# Build artifact
+/*.tgz

--- a/helm/openmrs-tenant/Chart.yaml
+++ b/helm/openmrs-tenant/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: openmrs-tenant
+description: OpenMRS Tenant Helm chart — minimal backend+frontend for one tenant sharing existing infrastructure
+type: application
+version: 0.1.0
+appVersion: "nightly-core-2.8"

--- a/helm/openmrs-tenant/Chart.yaml
+++ b/helm/openmrs-tenant/Chart.yaml
@@ -3,4 +3,4 @@ name: openmrs-tenant
 description: OpenMRS Tenant Helm chart — minimal backend+frontend for one tenant sharing existing infrastructure
 type: application
 version: 0.1.0
-appVersion: "nightly-core-2.8"
+appVersion: "3.7.x-no-demo"

--- a/helm/openmrs-tenant/templates/NOTES.txt
+++ b/helm/openmrs-tenant/templates/NOTES.txt
@@ -1,0 +1,12 @@
+Congratulations! The OpenMRS Tenant has been successfully deployed!
+
+Tenant: {{ .Values.tenant.name }}
+Backend: {{ include "openmrs-tenant.backend.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.backend.service.port }}
+Frontend: {{ include "openmrs-tenant.frontend.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.frontend.service.port }}
+
+To verify the tenant label:
+  kubectl get pods -n {{ .Release.Namespace }} -L app.kubernetes.io/tenant
+
+To port-forward for local access:
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "openmrs-tenant.backend.fullname" . }} 8080:{{ .Values.backend.service.port }}
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "openmrs-tenant.frontend.fullname" . }} 8081:{{ .Values.frontend.service.port }}

--- a/helm/openmrs-tenant/templates/NOTES.txt
+++ b/helm/openmrs-tenant/templates/NOTES.txt
@@ -7,6 +7,11 @@ Frontend: {{ include "openmrs-tenant.frontend.fullname" . }}.{{ .Release.Namespa
 To verify the tenant label:
   kubectl get pods -n {{ .Release.Namespace }} -L app.kubernetes.io/tenant
 
-To port-forward for local access:
+To port-forward the backend API for local access:
   kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "openmrs-tenant.backend.fullname" . }} 8080:{{ .Values.backend.service.port }}
+
+The frontend can be port-forwarded too, but note the SPA UI is not fully usable
+this way yet: the app shell requests its assets under SPA_PATH ({{ .Values.frontend.spaPath }}),
+which need a gateway rewrite to resolve, so they 404 over a plain port-forward
+(you get a blank page). Tenant HTTPRoute support lands under TRUNK-6654.
   kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "openmrs-tenant.frontend.fullname" . }} 8081:{{ .Values.frontend.service.port }}

--- a/helm/openmrs-tenant/templates/_helpers.tpl
+++ b/helm/openmrs-tenant/templates/_helpers.tpl
@@ -1,0 +1,73 @@
+{{- define "openmrs-tenant.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "openmrs-tenant.backend.name" -}}
+{{- default "backend" .Values.backend.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "openmrs-tenant.backend.fullname" -}}
+{{- if .Values.backend.fullnameOverride }}
+{{- .Values.backend.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name (default "backend" .Values.backend.nameOverride) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{- define "openmrs-tenant.backend.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "openmrs-tenant.backend.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "openmrs-tenant.backend.labels" -}}
+helm.sh/chart: {{ include "openmrs-tenant.chart" . }}
+{{ include "openmrs-tenant.backend.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/tenant: {{ required "tenant.name is required" .Values.tenant.name }}
+{{- end }}
+
+{{- define "openmrs-tenant.backend.serviceAccountName" -}}
+{{- if .Values.backend.serviceAccount.create }}
+{{- default (include "openmrs-tenant.backend.fullname" .) .Values.backend.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.backend.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "openmrs-tenant.frontend.name" -}}
+{{- default "frontend" .Values.frontend.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "openmrs-tenant.frontend.fullname" -}}
+{{- if .Values.frontend.fullnameOverride }}
+{{- .Values.frontend.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name (default "frontend" .Values.frontend.nameOverride) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{- define "openmrs-tenant.frontend.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "openmrs-tenant.frontend.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "openmrs-tenant.frontend.labels" -}}
+helm.sh/chart: {{ include "openmrs-tenant.chart" . }}
+{{ include "openmrs-tenant.frontend.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/tenant: {{ required "tenant.name is required" .Values.tenant.name }}
+{{- end }}
+
+{{- define "openmrs-tenant.frontend.serviceAccountName" -}}
+{{- if .Values.frontend.serviceAccount.create }}
+{{- default (include "openmrs-tenant.frontend.fullname" .) .Values.frontend.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.frontend.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/openmrs-tenant/templates/backend-configmap.yaml
+++ b/helm/openmrs-tenant/templates/backend-configmap.yaml
@@ -19,4 +19,4 @@ data:
   {{- else }}
   cache.type: "local"
   {{- end }}
-  storage.type: "local"
+  storage.type: {{ .Values.backend.storage.type | quote }}

--- a/helm/openmrs-tenant/templates/backend-configmap.yaml
+++ b/helm/openmrs-tenant/templates/backend-configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "openmrs-tenant.backend.fullname" . }}
+  labels:
+    {{- include "openmrs-tenant.backend.labels" . | nindent 4 }}
+data:
+  OMRS_DB: "mariadb"
+  OMRS_DB_HOSTNAME: {{ required "backend.db.hostname is required" .Values.backend.db.hostname | quote }}
+  OMRS_DB_PORT: {{ .Values.backend.db.port | quote }}
+  OMRS_DB_NAME: {{ required "backend.db.database is required" .Values.backend.db.database | quote }}
+  {{- if .Values.backend.db.url }}
+  OMRS_DB_URL: {{ .Values.backend.db.url | quote }}
+  {{- else }}
+  OMRS_DB_URL: {{ printf "jdbc:mariadb://%s:%s/%s?autoReconnect=true&sessionVariables=default_storage_engine=InnoDB&useUnicode=true&characterEncoding=UTF-8&useMysqlMetadata=true" .Values.backend.db.hostname (toString .Values.backend.db.port) .Values.backend.db.database | quote }}
+  {{- end }}
+  {{- if .Values.backend.infinispan.clustered }}
+  cache.type: "cluster"
+  {{- else }}
+  cache.type: "local"
+  {{- end }}
+  storage.type: "local"

--- a/helm/openmrs-tenant/templates/backend-secret.yaml
+++ b/helm/openmrs-tenant/templates/backend-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "openmrs-tenant.backend.fullname" . }}
+  labels:
+    {{- include "openmrs-tenant.backend.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  OMRS_DB_USERNAME: {{ required "backend.db.user is required" .Values.backend.db.user | quote }}
+  OMRS_DB_PASSWORD: {{ required "backend.db.password is required" .Values.backend.db.password | quote }}

--- a/helm/openmrs-tenant/templates/backend-service.yaml
+++ b/helm/openmrs-tenant/templates/backend-service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openmrs-tenant.backend.fullname" . }}
+  labels:
+    {{- include "openmrs-tenant.backend.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.backend.service.type }}
+  ports:
+    - port: {{ .Values.backend.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    {{- if .Values.backend.infinispan.clustered }}
+    - port: {{ .Values.backend.infinispan.bind_port }}
+      targetPort: infinispan-hibernate
+      protocol: TCP
+      name: infinispan-hibernate
+    - port: {{ add .Values.backend.infinispan.bind_port 1 }}
+      targetPort: infinispan-api
+      protocol: TCP
+      name: infinispan-api
+    {{- end }}
+  selector:
+    {{- include "openmrs-tenant.backend.selectorLabels" . | nindent 4 }}

--- a/helm/openmrs-tenant/templates/backend-service.yaml
+++ b/helm/openmrs-tenant/templates/backend-service.yaml
@@ -13,11 +13,11 @@ spec:
       name: http
     {{- if .Values.backend.infinispan.clustered }}
     - port: {{ .Values.backend.infinispan.bind_port }}
-      targetPort: infinispan-hibernate
+      targetPort: {{ .Values.backend.infinispan.bind_port }}
       protocol: TCP
       name: infinispan-hibernate
     - port: {{ add .Values.backend.infinispan.bind_port 1 }}
-      targetPort: infinispan-api
+      targetPort: {{ add .Values.backend.infinispan.bind_port 1 }}
       protocol: TCP
       name: infinispan-api
     {{- end }}

--- a/helm/openmrs-tenant/templates/backend-serviceaccount.yaml
+++ b/helm/openmrs-tenant/templates/backend-serviceaccount.yaml
@@ -11,7 +11,6 @@ metadata:
   {{- end }}
 automountServiceAccountToken: {{ .Values.backend.serviceAccount.automount }}
 
-{{- if .Values.backend.infinispan.clustered }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -39,5 +38,4 @@ roleRef:
   kind: Role
   name: {{ include "openmrs-tenant.backend.serviceAccountName" . }}-statefulset-reader
   apiGroup: rbac.authorization.k8s.io
-{{- end }}
 {{- end }}

--- a/helm/openmrs-tenant/templates/backend-serviceaccount.yaml
+++ b/helm/openmrs-tenant/templates/backend-serviceaccount.yaml
@@ -11,6 +11,7 @@ metadata:
   {{- end }}
 automountServiceAccountToken: {{ .Values.backend.serviceAccount.automount }}
 
+{{- if .Values.backend.infinispan.clustered }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -38,4 +39,5 @@ roleRef:
   kind: Role
   name: {{ include "openmrs-tenant.backend.serviceAccountName" . }}-statefulset-reader
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/helm/openmrs-tenant/templates/backend-serviceaccount.yaml
+++ b/helm/openmrs-tenant/templates/backend-serviceaccount.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.backend.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openmrs-tenant.backend.serviceAccountName" . }}
+  labels:
+    {{- include "openmrs-tenant.backend.labels" . | nindent 4 }}
+  {{- with .Values.backend.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.backend.serviceAccount.automount }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "openmrs-tenant.backend.serviceAccountName" . }}-statefulset-reader
+  labels:
+    {{- include "openmrs-tenant.backend.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "openmrs-tenant.backend.serviceAccountName" . }}-statefulset-reader-binding
+  labels:
+    {{- include "openmrs-tenant.backend.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "openmrs-tenant.backend.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "openmrs-tenant.backend.serviceAccountName" . }}-statefulset-reader
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/helm/openmrs-tenant/templates/backend-statefulset.yaml
+++ b/helm/openmrs-tenant/templates/backend-statefulset.yaml
@@ -66,6 +66,11 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /openmrs/data
+      {{- if not .Values.backend.persistence.enabled }}
+      volumes:
+        - name: data
+          emptyDir: {}
+      {{- end }}
       {{- with .Values.backend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -84,7 +89,9 @@ spec:
         name: data
       spec:
         accessModes: [ "ReadWriteOnce" ]
-        storageClassName: {{ (.Values.backend.persistence.storageClass | default .Values.global.defaultStorageClass) | quote }}
+        {{- with .Values.backend.persistence.storageClass | default .Values.global.defaultStorageClass }}
+        storageClassName: {{ . | quote }}
+        {{- end }}
         resources:
           requests:
             storage: {{ .Values.backend.persistence.size | quote }}

--- a/helm/openmrs-tenant/templates/backend-statefulset.yaml
+++ b/helm/openmrs-tenant/templates/backend-statefulset.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "openmrs-tenant.backend.fullname" . }}
+  labels:
+    {{- include "openmrs-tenant.backend.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.backend.autoscaling.enabled }}
+  replicas: {{ .Values.backend.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "openmrs-tenant.backend.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/backend-configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/backend-secret.yaml") . | sha256sum }}
+        {{- with .Values.backend.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "openmrs-tenant.backend.labels" . | nindent 8 }}
+        {{- with .Values.backend.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "openmrs-tenant.backend.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.backend.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.backend.securityContext | nindent 12 }}
+          image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.backend.service.port }}
+              protocol: TCP
+            {{- if .Values.backend.infinispan.clustered }}
+            - name: infinispan-hibernate
+              containerPort: {{ .Values.backend.infinispan.bind_port }}
+              protocol: TCP
+            - name: infinispan-api
+              containerPort: {{ add .Values.backend.infinispan.bind_port 1 }}
+              protocol: TCP
+            {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.backend.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.backend.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.backend.startupProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "openmrs-tenant.backend.fullname" . }}
+            - secretRef:
+                name: {{ include "openmrs-tenant.backend.fullname" . }}
+          volumeMounts:
+            - name: data
+              mountPath: /openmrs/data
+      {{- with .Values.backend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.backend.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ (.Values.backend.persistence.storageClass | default .Values.global.defaultStorageClass) | quote }}
+        resources:
+          requests:
+            storage: {{ .Values.backend.persistence.size | quote }}
+  {{- end }}

--- a/helm/openmrs-tenant/templates/backend-statefulset.yaml
+++ b/helm/openmrs-tenant/templates/backend-statefulset.yaml
@@ -43,10 +43,12 @@ spec:
               containerPort: {{ .Values.backend.service.port }}
               protocol: TCP
             {{- if .Values.backend.infinispan.clustered }}
-            - name: infinispan-hibernate
+            # Port names must be <= 15 chars (Kubernetes limit for container
+            # port names and string targetPorts), hence "ispn-" not "infinispan-".
+            - name: ispn-hibernate
               containerPort: {{ .Values.backend.infinispan.bind_port }}
               protocol: TCP
-            - name: infinispan-api
+            - name: ispn-api
               containerPort: {{ add .Values.backend.infinispan.bind_port 1 }}
               protocol: TCP
             {{- end }}

--- a/helm/openmrs-tenant/templates/frontend-configmap.yaml
+++ b/helm/openmrs-tenant/templates/frontend-configmap.yaml
@@ -6,4 +6,4 @@ metadata:
     {{- include "openmrs-tenant.frontend.labels" . | nindent 4 }}
 data:
   SPA_PATH: "/openmrs/spa"
-  API_URL: "/openmrs"
+  API_URL: "{{ .Values.frontend.apiUrl }}"

--- a/helm/openmrs-tenant/templates/frontend-configmap.yaml
+++ b/helm/openmrs-tenant/templates/frontend-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "openmrs-tenant.frontend.fullname" . }}
+  labels:
+    {{- include "openmrs-tenant.frontend.labels" . | nindent 4 }}
+data:
+  SPA_PATH: "/openmrs/spa"
+  API_URL: "/openmrs"

--- a/helm/openmrs-tenant/templates/frontend-configmap.yaml
+++ b/helm/openmrs-tenant/templates/frontend-configmap.yaml
@@ -5,5 +5,9 @@ metadata:
   labels:
     {{- include "openmrs-tenant.frontend.labels" . | nindent 4 }}
 data:
-  SPA_PATH: "/openmrs/spa"
-  API_URL: "{{ .Values.frontend.apiUrl }}"
+  SPA_PATH: {{ .Values.frontend.spaPath | quote }}
+  API_URL: {{ .Values.frontend.apiUrl | quote }}
+  SPA_DEFAULT_LOCALE: {{ .Values.frontend.defaultLocale | quote }}
+  {{- with .Values.frontend.configUrls }}
+  SPA_CONFIG_URLS: {{ . | quote }}
+  {{- end }}

--- a/helm/openmrs-tenant/templates/frontend-deployment.yaml
+++ b/helm/openmrs-tenant/templates/frontend-deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "openmrs-tenant.frontend.fullname" . }}
+  labels:
+    {{- include "openmrs-tenant.frontend.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.frontend.autoscaling.enabled }}
+  replicas: {{ .Values.frontend.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "openmrs-tenant.frontend.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/frontend-configmap.yaml") . | sha256sum }}
+        {{- with .Values.frontend.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "openmrs-tenant.frontend.labels" . | nindent 8 }}
+        {{- with .Values.frontend.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "openmrs-tenant.frontend.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.frontend.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.frontend.securityContext | nindent 12 }}
+          image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.frontend.service.port }}
+              protocol: TCP
+          command: ["/usr/local/bin/startup.sh"]
+          livenessProbe:
+            {{- toYaml .Values.frontend.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.frontend.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "openmrs-tenant.frontend.fullname" . }}
+          {{- with .Values.frontend.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.frontend.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.frontend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.frontend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.frontend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/openmrs-tenant/templates/frontend-service.yaml
+++ b/helm/openmrs-tenant/templates/frontend-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openmrs-tenant.frontend.fullname" . }}
+  labels:
+    {{- include "openmrs-tenant.frontend.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.frontend.service.type }}
+  ports:
+    - port: {{ .Values.frontend.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "openmrs-tenant.frontend.selectorLabels" . | nindent 4 }}

--- a/helm/openmrs-tenant/templates/frontend-serviceaccount.yaml
+++ b/helm/openmrs-tenant/templates/frontend-serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.frontend.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openmrs-tenant.frontend.serviceAccountName" . }}
+  labels:
+    {{- include "openmrs-tenant.frontend.labels" . | nindent 4 }}
+  {{- with .Values.frontend.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.frontend.serviceAccount.automount }}
+{{- end }}

--- a/helm/openmrs-tenant/values.yaml
+++ b/helm/openmrs-tenant/values.yaml
@@ -1,0 +1,149 @@
+tenant:
+  name: ""
+  hostname: ""
+
+global:
+  defaultStorageClass: "gp2"
+
+imagePullSecrets: []
+
+backend:
+  nameOverride: "backend"
+  fullnameOverride: ""
+
+  image:
+    repository: openmrs/openmrs-reference-application-3-backend
+    tag: ""
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  serviceAccount:
+    create: true
+    automount: true
+    annotations: {}
+    name: ""
+
+  service:
+    type: ClusterIP
+    port: 8080
+
+  persistence:
+    enabled: true
+    size: 8Gi
+    storageClass: ""
+
+  podSecurityContext:
+    fsGroup: 1001
+    runAsUser: 1001
+    fsGroupChangePolicy: "Always"
+
+  securityContext: {}
+
+  resources:
+    limits:
+      cpu: 4
+      memory: 4Gi
+    requests:
+      cpu: 1000m
+      memory: 2Gi
+
+  livenessProbe:
+    httpGet:
+      path: /openmrs/health/started
+      port: 8080
+    failureThreshold: 3
+    timeoutSeconds: 1
+    periodSeconds: 10
+  readinessProbe:
+    httpGet:
+      path: /openmrs/health/started
+      port: 8080
+    initialDelaySeconds: 60
+    failureThreshold: 10
+    timeoutSeconds: 5
+    periodSeconds: 15
+  startupProbe:
+    httpGet:
+      path: /openmrs/health/started
+      port: 8080
+    initialDelaySeconds: 20
+    failureThreshold: 120
+    timeoutSeconds: 1
+    periodSeconds: 10
+
+  autoscaling:
+    enabled: false
+
+  db:
+    hostname: ""
+    port: 3306
+    database: ""
+    user: ""
+    password: ""
+    url: ""
+
+  infinispan:
+    clustered: false
+    bind_port: 7800
+
+  podAnnotations: {}
+  podLabels: {}
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+frontend:
+  nameOverride: "frontend"
+  fullnameOverride: ""
+
+  image:
+    repository: openmrs/openmrs-reference-application-3-frontend
+    tag: ""
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  serviceAccount:
+    create: false
+    automount: false
+    annotations: {}
+    name: ""
+
+  service:
+    type: ClusterIP
+    port: 80
+
+  podSecurityContext: {}
+
+  securityContext: {}
+
+  resources: {}
+
+  livenessProbe:
+    httpGet:
+      path: /
+      port: http
+    failureThreshold: 3
+    timeoutSeconds: 1
+    periodSeconds: 10
+  readinessProbe:
+    httpGet:
+      path: /
+      port: http
+    failureThreshold: 3
+    timeoutSeconds: 1
+    periodSeconds: 10
+
+  autoscaling:
+    enabled: false
+
+  podAnnotations: {}
+  podLabels: {}
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  volumes: []
+  volumeMounts: []

--- a/helm/openmrs-tenant/values.yaml
+++ b/helm/openmrs-tenant/values.yaml
@@ -3,7 +3,7 @@ tenant:
   hostname: ""
 
 global:
-  defaultStorageClass: "gp2"
+  defaultStorageClass: ""
 
 imagePullSecrets: []
 
@@ -95,6 +95,7 @@ backend:
   affinity: {}
 
 frontend:
+  apiUrl: "/openmrs"
   nameOverride: "frontend"
   fullnameOverride: ""
 

--- a/helm/openmrs-tenant/values.yaml
+++ b/helm/openmrs-tenant/values.yaml
@@ -72,6 +72,9 @@ backend:
     timeoutSeconds: 1
     periodSeconds: 10
 
+  storage:
+    type: "local"
+
   autoscaling:
     enabled: false
 
@@ -95,7 +98,7 @@ backend:
   affinity: {}
 
 frontend:
-  apiUrl: "/openmrs"
+  apiUrl: "http://localhost:8080/openmrs"
   nameOverride: "frontend"
   fullnameOverride: ""
 

--- a/helm/openmrs-tenant/values.yaml
+++ b/helm/openmrs-tenant/values.yaml
@@ -13,7 +13,7 @@ backend:
 
   image:
     repository: openmrs/openmrs-reference-application-3-backend
-    tag: ""
+    tag: "3.7.x-no-demo"
     pullPolicy: IfNotPresent
 
   replicaCount: 1
@@ -107,7 +107,7 @@ frontend:
 
   image:
     repository: openmrs/openmrs-reference-application-3-frontend
-    tag: ""
+    tag: "3.7.x"
     pullPolicy: IfNotPresent
 
   replicaCount: 1

--- a/helm/openmrs-tenant/values.yaml
+++ b/helm/openmrs-tenant/values.yaml
@@ -99,6 +99,9 @@ backend:
 
 frontend:
   apiUrl: "http://localhost:8080/openmrs"
+  spaPath: "/openmrs/spa"
+  defaultLocale: "en"
+  configUrls: ""
   nameOverride: "frontend"
   fullnameOverride: ""
 


### PR DESCRIPTION
## Summary
Adds `helm/openmrs-tenant`, a chart that deploys an isolated OpenMRS tenant (backend + frontend) sharing the primary cluster's infrastructure.

Following [#28](https://github.com/openmrs/openmrs-contrib-cluster/pull/28): which made openmrs-backend / openmrs-frontend infra-free, reusable charts, this is a thin umbrella: it depends on those two charts (2.0.0) and supplies only the per-tenant configuration. It does not fork or re-declare any backend/frontend templates, so tenants inherit the reviewed shared-chart behaviour with no drift.

## What a tenant provides
`openmrs-backend.db.url` / `.username` / `.password` — connection to the shared MariaDB (per-tenant database + user)
`openmrs-frontend.spaPath` / `.apiUrl` / `.defaultLocale` / `.configUrls` — SPA config `app.kubernetes.io`/tenant pod label via podLabels
Each tenant is a separate Helm release in its own namespace.

JIRA Ticket: https://openmrs.atlassian.net/browse/TRUNK-6652 