### PR TITLE
TRUNK-6676: Update Helm charts to use OpenMRS 3.7.x Docker images

### DIFF
--- a/helm/kind-openmrs.yaml
+++ b/helm/kind-openmrs.yaml
@@ -3,7 +3,7 @@ global:
 openmrs-backend:
   image:
     repository: openmrs/openmrs-reference-application-3-backend
-    tag: nightly-0-core-2.8
+    tag: 3.7.x-no-demo
     pullPolicy: IfNotPresent #IfNotPresent / Always
   replicaCount: 2
   startupProbe:
@@ -128,5 +128,5 @@ openmrs-frontend:
     enabled: true
   image:
     repository: openmrs/openmrs-reference-application-3-frontend
-    tag: nightly-0-core-2.8
+    tag: 3.7.x
     pullPolicy: IfNotPresent #IfNotPresent / Always

--- a/helm/openmrs-backend/Chart.yaml
+++ b/helm/openmrs-backend/Chart.yaml
@@ -21,7 +21,7 @@ version: 1.3.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "nightly-core-2.8"
+appVersion: "3.7.x-no-demo"
 
 dependencies:
 

--- a/helm/openmrs-frontend/Chart.yaml
+++ b/helm/openmrs-frontend/Chart.yaml
@@ -21,4 +21,4 @@ version: 1.2.2
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "nightly-0-core-2.8"
+appVersion: "3.7.x"

--- a/helm/openmrs/Chart.yaml
+++ b/helm/openmrs/Chart.yaml
@@ -21,7 +21,7 @@ version: 1.2.2
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "nightly-0-core-2.8"
+appVersion: "3.7.x"
 
 dependencies:
   - name: openmrs-backend

--- a/helm/scripts/bootstrap.sh
+++ b/helm/scripts/bootstrap.sh
@@ -15,8 +15,8 @@ SKIP_OPENMRS="${SKIP_OPENMRS:-false}"
 
 KNOWN_IMAGES=(
   "mariadb:10.11"
-  "openmrs/openmrs-reference-application-3-backend:nightly-0-core-2.8"
-  "openmrs/openmrs-reference-application-3-frontend:nightly-0-core-2.8"
+  "openmrs/openmrs-reference-application-3-backend:3.7.x-no-demo"
+  "openmrs/openmrs-reference-application-3-frontend:3.7.x"
   "openmrs/openmrs-contrib-elasticsearch:8.15.3"
 )
 


### PR DESCRIPTION
Updates Helm charts to use OpenMRS 3.7.x Docker images, replacing the nightly-core-2.8 images.