### PR TITLE
TRUNK 6671:  Add headless service for JGroups DNS_PING and remove infinispan ports from ClusterIP

### DIFF
--- a/helm/openmrs-backend/templates/NOTES.txt
+++ b/helm/openmrs-backend/templates/NOTES.txt
@@ -1,11 +1,11 @@
 Congratulations! The OpenMRS Backend has been successfully deployed!
 
 To access the service run:
-  kubectl -n {{ .Release.Namespace }} port-forward svc/backend 8080:8080
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "openmrs-backend.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
 
 NOTE: In case port-forward command does not work, make sure that OpenMRS Backend name is correct.
       Check the services in {{ .Release.Namespace }} namespace using:
         kubectl -n {{ .Release.Namespace }} get svc
 
 The OpenMRS backend will be available at:
-  http://localhost:8080
+  http://localhost:{{ .Values.service.port }}/openmrs/

--- a/helm/openmrs-backend/templates/_helpers.tpl
+++ b/helm/openmrs-backend/templates/_helpers.tpl
@@ -87,3 +87,10 @@ Full internal cluster URL for the ECK-managed Elasticsearch HTTP service.
 {{- define "openmrs-seaweedfs.s3url" -}}
 {{- printf "http://%s-seaweedfs-s3.%s.svc.cluster.local:8333" .Release.Name .Release.Namespace }}
 {{- end }}
+
+{{/*
+Headless Service name used for JGroups DNS_PING discovery.
+*/}}
+{{- define "openmrs-backend.headlessServiceName" -}}
+{{- printf "%s-headless" (include "openmrs-backend.fullname" .) -}}
+{{- end }}

--- a/helm/openmrs-backend/templates/configmap.yaml
+++ b/helm/openmrs-backend/templates/configmap.yaml
@@ -48,7 +48,7 @@ data:
   {{- if .Values.infinispan.clustered }}
   cache.type: "cluster"
   cache.stack: "kubernetes"
-  jgroups.dns.query: '{{ include "openmrs-backend.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local'
+  jgroups.dns.query: '{{ include "openmrs-backend.fullname" . }}-headless.{{ .Release.Namespace }}.svc.cluster.local'
   jgroups.bind.port: {{ .Values.infinispan.bind_port | quote }}
   {{- else }}
   cache.type: "local"

--- a/helm/openmrs-backend/templates/configmap.yaml
+++ b/helm/openmrs-backend/templates/configmap.yaml
@@ -48,7 +48,7 @@ data:
   {{- if .Values.infinispan.clustered }}
   cache.type: "cluster"
   cache.stack: "kubernetes"
-  jgroups.dns.query: '{{ include "openmrs-backend.fullname" . }}-headless.{{ .Release.Namespace }}.svc.cluster.local'
+  jgroups.dns.query: '{{ include "openmrs-backend.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local'
   jgroups.bind.port: {{ .Values.infinispan.bind_port | quote }}
   {{- else }}
   cache.type: "local"

--- a/helm/openmrs-backend/templates/headless-service.yaml
+++ b/helm/openmrs-backend/templates/headless-service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openmrs-backend.fullname" . }}-headless
+  labels:
+    {{- include "openmrs-backend.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    {{- include "openmrs-backend.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+    {{- if .Values.infinispan.clustered }}
+    - name: infinispan-hibernate
+      port: {{ .Values.infinispan.bind_port }}
+      targetPort: {{ .Values.infinispan.bind_port }}
+      protocol: TCP
+    - name: infinispan-api
+      port: {{ add .Values.infinispan.bind_port 1 }}
+      targetPort: {{ add .Values.infinispan.bind_port 1 }}
+      protocol: TCP
+    {{- end }}

--- a/helm/openmrs-backend/templates/headless-service.yaml
+++ b/helm/openmrs-backend/templates/headless-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.infinispan.clustered }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -11,11 +12,6 @@ spec:
   selector:
     {{- include "openmrs-backend.selectorLabels" . | nindent 4 }}
   ports:
-    - name: http
-      port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
-    {{- if .Values.infinispan.clustered }}
     - name: infinispan-hibernate
       port: {{ .Values.infinispan.bind_port }}
       targetPort: {{ .Values.infinispan.bind_port }}
@@ -24,4 +20,4 @@ spec:
       port: {{ add .Values.infinispan.bind_port 1 }}
       targetPort: {{ add .Values.infinispan.bind_port 1 }}
       protocol: TCP
-    {{- end }}
+{{- end }}

--- a/helm/openmrs-backend/templates/headless-service.yaml
+++ b/helm/openmrs-backend/templates/headless-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "openmrs-backend.fullname" . }}-headless
+  name: {{ include "openmrs-backend.headlessServiceName" . }}
   labels:
     {{- include "openmrs-backend.labels" . | nindent 4 }}
 spec:

--- a/helm/openmrs-backend/templates/service.yaml
+++ b/helm/openmrs-backend/templates/service.yaml
@@ -11,15 +11,5 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-    {{ if .Values.infinispan.clustered }}
-    - port: {{ .Values.infinispan.bind_port }}
-      targetPort: {{ .Values.infinispan.bind_port }}
-      protocol: TCP
-      name: infinispan-hibernate
-    - port: {{ add .Values.infinispan.bind_port 1 }}
-      targetPort: {{ add .Values.infinispan.bind_port 1 }}
-      protocol: TCP
-      name: infinispan-api
-    {{ end }}
   selector:
     {{- include "openmrs-backend.selectorLabels" . | nindent 4 }}

--- a/helm/openmrs-frontend/templates/NOTES.txt
+++ b/helm/openmrs-frontend/templates/NOTES.txt
@@ -1,11 +1,11 @@
 Congratulations! The OpenMRS Frontend has been successfully deployed!
 
 To access the service run:
-  kubectl -n {{ .Release.Namespace }} port-forward svc/frontend 8080:80
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "openmrs-frontend.fullname" . }} 8080:{{ .Values.service.port }}
 
 NOTE: In case port-forward command does not work, make sure that OpenMRS Frontend name is correct.
       Check the services in {{ .Release.Namespace }} namespace using:
         kubectl -n {{ .Release.Namespace }} get svc
 
 The OpenMRS Frontend will be available at:
-  http://localhost:8080
+  http://localhost:8080/openmrs/spa/home


### PR DESCRIPTION
## Problem
Infinispan cached entries were not replicating across backend replicas. Each pod formed a singleton cluster (view size=1) because JGroups DNS_PING was resolving the ClusterIP service FQDN, which returns a single VIP, not individual pod IPs.

## Three changes to openmrs-backend Helm templates:
1. New `headless-service.yaml` a clusterIP: None Service with `publishNotReadyAddresses: true` so DNS returns one A record per pod, including during startup (before readiness probes pass).
2. `configmap.yaml` point `jgroups.dns.query` from the ClusterIP FQDN to the headless Service FQDN, so DNS_PING discovers all pods.
3. `service.yaml` remove Infinispan ports (7800/7801) from the ClusterIP Service. These were unnecessary (JGroups binds directly on pod IPs) and an unintended exposure.

No `StatefulSet.spec.serviceName` change, the headless Service selects pods by label, avoiding the immutable-field upgrade issue entirely.

## Verification
Tested on a Kind cluster with replicaCount: 2:
- Both pods 1/1 Ready
- DNS getent hosts openmrs-backend-headless.<ns>.svc.cluster.local returns both pod IPs
- Cross-pod TCP connections established on port 7800 (Hibernate cache)
- JGroups cross-cluster message exchange confirmed
- Zero runtime errors
- helm lint passes for both clustered and non-clustered paths

JIRA TICKET: https://openmrs.atlassian.net/browse/TRUNK-6671 