### PR TITLE
Wire claude-pr-review to this repo's pr-review skill

### DIFF
--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -14,6 +14,9 @@ jobs:
   review:
     uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/claude-pr-review.yml@main
     secrets: inherit
+    with:
+      skill_url: "https://raw.githubusercontent.com/openmrs/openmrs-contrib-cluster/8d7f0a3413b95048d969221780a186f229f04c27/.claude/skills/pr-review/SKILL.md"
+      show_full_output: true
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Added SHA to the skill-url to wire up `skill.md` for claude review