### PR TITLE
Decouple openmrs-operator's version from the umbrella release workflow

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -4,8 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "openmrs (umbrella) + openmrs-operator chart version (e.g. 1.2.1). openmrs-backend/openmrs-frontend are versioned independently — bump their Chart.yaml (and the umbrella's dependency pin) in a regular commit first."
+        description: "openmrs (umbrella) chart version (e.g. 2.0.0). openmrs-backend/openmrs-frontend are versioned independently — bump their Chart.yaml (and the umbrella's dependency pin) in a regular commit first."
         required: true
+      operator_version:
+        description: "openmrs-operator chart version — set this to give it a release (it versions independently and has no working prior release to preserve). Leave blank to leave its Chart.yaml version untouched."
+        required: false
 
 jobs:
   release:
@@ -40,12 +43,15 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         env:
           VERSION: ${{ github.event.inputs.version }}
+          OPERATOR_VERSION: ${{ github.event.inputs.operator_version }}
         run: |
           # openmrs-backend/openmrs-frontend version independently — bump them by
           # hand in a regular commit, not here. `helm dependency update` fails
           # loudly if their Chart.yaml drifts from the pin below.
           sed -i "s/^version: .*/version: $VERSION/" helm/openmrs/Chart.yaml
-          sed -i "s/^version: .*/version: $VERSION/" helm/openmrs-operator/Chart.yaml
+          if [[ -n "$OPERATOR_VERSION" ]]; then
+            sed -i "s/^version: .*/version: $OPERATOR_VERSION/" helm/openmrs-operator/Chart.yaml
+          fi
 
       - name: Build dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -427,14 +427,20 @@ dependencies and run helm upgrade.
 
 ### Releasing from Github Actions
 
-1. Go to the "Actions" tab in the GitHub repository.
-2. Select the "Release Charts" workflow from the left sidebar.
-3. Click the "Run workflow" dropdown button.
-4. Enter the desired version (e.g., `1.2.2`) in the "Chart version" input field.
-5. Click the green "Run workflow" button.
+1. Bump `openmrs-backend`/`openmrs-frontend` `Chart.yaml` (and the umbrella's dependency
+   pin on them in `helm/openmrs/Chart.yaml`) in a regular commit first — the workflow
+   below doesn't touch these two, they version independently of the umbrella.
+2. Go to the "Actions" tab in the GitHub repository.
+3. Select the "Release Charts" workflow from the left sidebar.
+4. Click the "Run workflow" dropdown button.
+5. Enter the desired umbrella version (e.g., `2.0.0`) in the "version" input field.
+   `openmrs-operator` versions independently and is left untouched unless you also
+   fill in "operator_version" — leave it blank to skip releasing it this round.
+6. Click the green "Run workflow" button.
 
 This will:
-- Update the version in `Chart.yaml` files.
+- Update the version in `helm/openmrs/Chart.yaml` (and `helm/openmrs-operator/Chart.yaml`
+  if `operator_version` was set).
 - Commit and push the changes.
 - Create a git tag.
 - Package and release the charts to GitHub Pages.


### PR DESCRIPTION
The "Release Charts" workflow force-set `openmrs-operator's` `Chart.yaml` version to whatever was dispatched for the umbrella, even when operator itself hadn't changed. Triggering the upcoming 2.0.0 release as-is would have bumped operator 1.3.0 -> 2.0.0 with no corresponding content change. Split it into its own optional input that defaults to leaving operator's version untouched, and updated the README's release instructions to match.