### PR TITLE
TRUNK-6652: Add openmrs-tenant chart for multi-tenant deployments

### DIFF
--- a/.github/workflows/helm-build.yaml
+++ b/.github/workflows/helm-build.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: Update Dependencies
         run: helm dependency update helm/openmrs
 
+      - name: Update Tenant Dependencies
+        run: helm dependency update helm/openmrs-tenant
+
       - name: Lint Main Chart
         run: helm lint helm/openmrs
 
@@ -76,6 +79,28 @@ jobs:
           grep -q 'OMRS_DB_USERNAME: "rdsuser"' /tmp/external-db.yaml
           grep -q 'OMRS_DB_NAME: "openmrs_rds"' /tmp/external-db.yaml
 
+      - name: Validate Rendering (external database via db.url)
+        run: |
+          # The db.url path must emit OMRS_DB (driver select) and OMRS_DB_HOSTNAME/PORT
+          # (startup wait-for-it) — without them the backend picks the wrong JDBC driver
+          # or waits on localhost. Exercised here at the openmrs-backend level, not only
+          # via a consumer chart.
+          helm template helm/openmrs-backend --generate-name \
+            --set global.mariadb.enabled=false \
+            --set db.url="jdbc:mariadb:loadbalance://ext-mariadb:3306/openmrs_ext" \
+            --set db.hostname=ext-mariadb \
+            --set db.username=extuser \
+            --set db.password=extpass > /tmp/backend-url.yaml
+          grep -q 'OMRS_DB: "mariadb"' /tmp/backend-url.yaml
+          grep -q 'OMRS_DB_HOSTNAME: "ext-mariadb"' /tmp/backend-url.yaml
+          grep -q 'OMRS_DB_URL: "jdbc:mariadb:loadbalance://ext-mariadb:3306/openmrs_ext"' /tmp/backend-url.yaml
+          if err=$(helm template helm/openmrs --generate-name \
+              --set global.mariadb.enabled=false \
+              --set openmrs-backend.db.url=jdbc:mariadb://ext-mariadb:3306/openmrs_ext 2>&1); then
+            echo "expected db.url with no db.hostname to be rejected"; exit 1
+          fi
+          grep -qF 'db.hostname is required alongside db.url' <<<"$err"
+
       - name: Validate Rendering (MariaDB replication mode)
         run: |
           helm template helm/openmrs --generate-name \
@@ -104,3 +129,52 @@ jobs:
           fail_if_renders openmrs-backend.seaweedfs.s3.enableAuth=true
           fail_if_renders openmrs-backend.seaweedfs.admin.ingress.enabled=true
           fail_if_renders openmrs-backend.seaweedfs.admin.enabled=true
+
+      - name: Lint and Render Tenant Chart
+        run: |
+          TENANT_VALUES="--set global.tenant.name=tenant1 \
+            --set openmrs-backend.db.url=jdbc:mariadb:loadbalance://mariadb.example.svc.cluster.local:3306/openmrs_tenant1?autoReconnect=true&sessionVariables=default_storage_engine=InnoDB&useUnicode=true&characterEncoding=UTF-8&useMysqlMetadata=true \
+            --set openmrs-backend.db.hostname=mariadb.example.svc.cluster.local \
+            --set openmrs-backend.db.username=ci_user \
+            --set openmrs-backend.db.password=ci-pass"
+          helm lint helm/openmrs-tenant $TENANT_VALUES
+          helm template tenant1 helm/openmrs-tenant $TENANT_VALUES > /tmp/tenant.yaml
+          grep -q 'name: tenant1-openmrs-backend' /tmp/tenant.yaml
+          grep -q 'name: tenant1-openmrs-frontend' /tmp/tenant.yaml
+          grep -q 'OMRS_DB_URL: "jdbc:mariadb:loadbalance://mariadb.example.svc.cluster.local:3306/openmrs_tenant1?autoReconnect=true&sessionVariables=default_storage_engine=InnoDB&useUnicode=true&characterEncoding=UTF-8&useMysqlMetadata=true"' /tmp/tenant.yaml
+          grep -q 'OMRS_DB_HOSTNAME: "mariadb.example.svc.cluster.local"' /tmp/tenant.yaml
+          grep -q 'SPA_PATH: "/openmrs/spa"' /tmp/tenant.yaml
+          [ "$(grep -c 'app.kubernetes.io/tenant: "tenant1"' /tmp/tenant.yaml)" -eq 2 ]
+          if grep -q 'storageClassName: ""' /tmp/tenant.yaml; then
+            echo "empty storageClassName means no-class (PVC stays Pending); it must be omitted"; exit 1
+          fi
+          # Phase-1 invariant: tenant routing is deferred to Phase 3 (TRUNK-6654), so the
+          # shared charts' HTTPRoutes are disabled by default — a host-less route would
+          # collide with the primary and other tenants on the shared gateway.
+          if grep -q 'kind: HTTPRoute' /tmp/tenant.yaml; then
+            echo "expected NO HTTPRoutes in the default tenant render (gateway must stay off until Phase 3)"; exit 1
+          fi
+          # DB connection is required: a tenant without db.url/hostname/username/password
+          # must fail to render, not silently fall back to the shared backend's
+          # primary-DB defaults (host "mariadb"/db "openmrs").
+          if err=$(helm template tenant1 helm/openmrs-tenant --set global.tenant.name=tenant1 2>&1); then
+            echo "expected the db guard to reject a tenant with no database configured"; exit 1
+          fi
+          grep -qF 'openmrs-tenant: openmrs-backend.db.url' <<<"$err"
+          if err=$(helm template tenant1 helm/openmrs-tenant --set openmrs-backend.db.url=jdbc:x --set openmrs-backend.db.hostname=h --set openmrs-backend.db.username=u --set openmrs-backend.db.password=p 2>&1); then
+            echo "expected the guard to reject a tenant with no global.tenant.name"; exit 1
+          fi
+          grep -qF 'openmrs-tenant: global.tenant.name is required' <<<"$err"
+          # Forward check (Phase 3): when routing IS enabled, the per-tenant spaPath still
+          # reaches the route match and the redirect target, not just the ConfigMap.
+          helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+            --set openmrs-backend.gateway.enabled=true \
+            --set openmrs-frontend.gateway.enabled=true \
+            --set openmrs-frontend.spaPath=/tenant-a/spa \
+            --set openmrs-frontend.rootRedirect.enabled=true > /tmp/tenant-spa.yaml
+          grep -q 'SPA_PATH: "/tenant-a/spa"' /tmp/tenant-spa.yaml
+          grep -q 'value: /tenant-a/spa' /tmp/tenant-spa.yaml
+          grep -q 'replaceFullPath: /tenant-a/spa/home' /tmp/tenant-spa.yaml
+          # Clustered infinispan still renders
+          helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+            --set openmrs-backend.infinispan.clustered=true > /dev/null

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "openmrs (umbrella) chart version (e.g. 2.0.0). openmrs-backend/openmrs-frontend are versioned independently — bump their Chart.yaml (and the umbrella's dependency pin) in a regular commit first."
+        description: "openmrs (umbrella) chart version (e.g. 2.0.0). openmrs-backend/openmrs-frontend/openmrs-tenant are versioned independently — bump their Chart.yaml (and any dependency pin) in a regular commit first."
         required: true
       operator_version:
         description: "openmrs-operator chart version — set this to give it a release (it versions independently and has no working prior release to preserve). Leave blank to leave its Chart.yaml version untouched."
@@ -45,9 +45,9 @@ jobs:
           VERSION: ${{ github.event.inputs.version }}
           OPERATOR_VERSION: ${{ github.event.inputs.operator_version }}
         run: |
-          # openmrs-backend/openmrs-frontend version independently — bump them by
-          # hand in a regular commit, not here. `helm dependency update` fails
-          # loudly if their Chart.yaml drifts from the pin below.
+          # openmrs-backend/openmrs-frontend/openmrs-tenant version independently — bump
+          # them by hand in a regular commit, not here. `helm dependency update` fails
+          # loudly if their Chart.yaml drifts from a pin below.
           sed -i "s/^version: .*/version: $VERSION/" helm/openmrs/Chart.yaml
           if [[ -n "$OPERATOR_VERSION" ]]; then
             sed -i "s/^version: .*/version: $OPERATOR_VERSION/" helm/openmrs-operator/Chart.yaml

--- a/README.md
+++ b/README.md
@@ -98,6 +98,132 @@ To disable monitoring (Grafana, Loki, Alloy), set `monitoring.enabled=false` in 
 | `SKIP_OPERATORS=true` | `false` | Skip `openmrs-operator` chart install |
 | `SKIP_OPENMRS=true` | `false` | Skip OpenMRS deployment (exit after step 3) |
 
+### 6. Deploy additional tenants (multi-tenancy)
+
+The `helm/openmrs-tenant` chart deploys an isolated OpenMRS tenant (backend + frontend)
+that shares the primary cluster's MariaDB. It is a **thin umbrella**: the backend and
+frontend workloads come from the shared `openmrs-backend` / `openmrs-frontend` charts
+(consumed as dependencies), and the tenant chart only supplies the per-tenant
+configuration on top of them. Each tenant is a separate Helm release in its own namespace.
+
+#### Prerequisites
+
+- Primary OpenMRS stack deployed and running (steps 1–4 above)
+- MariaDB accessible from tenant namespace (default DNS: `<primary-release>-mariadb.<primary-namespace>.svc.cluster.local`, e.g. `openmrs-mariadb.openmrs.svc.cluster.local`)
+- A database and user created for the tenant:
+
+```bash
+kubectl exec -n openmrs svc/openmrs-mariadb -- mysql -u root -pRoot123 -e "
+  CREATE DATABASE IF NOT EXISTS openmrs_<tenant> CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+  CREATE USER IF NOT EXISTS '<tenant>_user'@'%' IDENTIFIED BY '<password>';
+  GRANT ALL PRIVILEGES ON openmrs_<tenant>.* TO '<tenant>_user'@'%';
+  FLUSH PRIVILEGES;
+"
+```
+
+#### Install a tenant
+
+A tenant connects to the shared MariaDB via a full JDBC URL
+(`openmrs-backend.db.url`). `db.hostname` (and `db.port`) must point at the same
+MariaDB — the backend image's `wait-for-it` preflight gates on
+`OMRS_DB_HOSTNAME:OMRS_DB_PORT` (defaulting to `localhost:3306`, which never
+resolves), so the JDBC URL alone is not enough. Vendor the shared charts once,
+then install:
+
+```bash
+helm dependency update helm/openmrs-tenant   # once — vendors openmrs-backend/openmrs-frontend
+
+helm install <tenant> helm/openmrs-tenant \
+  -n tenant-<tenant> --create-namespace \
+  --set global.tenant.name=<tenant> \
+  --set global.defaultStorageClass=standard \
+  --set openmrs-backend.db.url="jdbc:mariadb:loadbalance://<primary-release>-mariadb.<primary-namespace>.svc.cluster.local:3306/openmrs_<tenant>?autoReconnect=true&sessionVariables=default_storage_engine=InnoDB&useUnicode=true&characterEncoding=UTF-8&useMysqlMetadata=true" \
+  --set openmrs-backend.db.hostname=<primary-release>-mariadb.<primary-namespace>.svc.cluster.local \
+  --set openmrs-backend.db.port=3306 \
+  --set openmrs-backend.db.username=<tenant>_user \
+  --set openmrs-backend.db.password=<password>
+```
+
+Example for a tenant named `coast`:
+
+```bash
+helm install coast helm/openmrs-tenant \
+  -n tenant-coast --create-namespace \
+  --set global.tenant.name=coast \
+  --set global.defaultStorageClass=standard \
+  --set openmrs-backend.db.url="jdbc:mariadb:loadbalance://openmrs-mariadb.openmrs.svc.cluster.local:3306/openmrs_coast?autoReconnect=true&sessionVariables=default_storage_engine=InnoDB&useUnicode=true&characterEncoding=UTF-8&useMysqlMetadata=true" \
+  --set openmrs-backend.db.hostname=openmrs-mariadb.openmrs.svc.cluster.local \
+  --set openmrs-backend.db.port=3306 \
+  --set openmrs-backend.db.username=coast_user \
+  --set openmrs-backend.db.password=CoastPass123
+```
+
+> **Naming:** resources are named from the **release name** (the first argument to
+> `helm install`) by the shared charts, e.g. release `coast` → `coast-openmrs-backend` /
+> `coast-openmrs-frontend`.
+>
+> **Tenant label:** `global.tenant.name` sets the `app.kubernetes.io/tenant` label on
+> the backend and frontend **pods** (it propagates into the shared charts as a global).
+> It does **not** land on Services/ConfigMaps — labelling every resource per tenant
+> would need a `commonLabels` hook on the shared charts (planned).
+
+#### Verification
+
+```bash
+# Check pods with tenant label
+kubectl get pods -n tenant-<tenant> -L app.kubernetes.io/tenant
+
+# Wait for ready
+kubectl wait --for=condition=ready pod -n tenant-<tenant> --all --timeout=600s
+
+# Port-forward to backend (API)
+kubectl port-forward -n tenant-<tenant> svc/<tenant>-openmrs-backend 8080:8080
+
+# Port-forward to frontend (SPA)
+kubectl port-forward -n tenant-<tenant> svc/<tenant>-openmrs-frontend 8081:80
+```
+
+> **Note on routing:** tenant HTTPRoutes are disabled in this chart
+> (`openmrs-backend.gateway.enabled` and `openmrs-frontend.gateway.enabled` default to
+> `false`) — per-tenant routing is deferred to a later phase (TRUNK-6654), since the
+> shared charts' routes carry no hostname and would collide on the shared gateway.
+> Reach the backend API via `kubectl port-forward` as shown. The **frontend SPA UI is
+> not fully usable over port-forward** — the app shell requests its assets under
+> `SPA_PATH` (`/openmrs/spa`), which needs a gateway rewrite (stripping the prefix
+> before nginx) that port-forward cannot provide. Once tenant routing lands, each
+> tenant's frontend and backend will sit behind a per-tenant hostname
+> (e.g. `<tenant>.example.com`), like the primary OpenMRS stack.
+
+#### Tenant chart parameters
+
+The tenant chart's own values, plus the most common shared-chart overrides it passes
+through. For the full shared-chart surface, see `helm/openmrs-backend/values.yaml` and
+`helm/openmrs-frontend/values.yaml`.
+
+| Name | Description | Default |
+|------|-------------|---------|
+| `global.tenant.name` | Tenant identifier; sets the `app.kubernetes.io/tenant` label on backend/frontend pods | **required** |
+| `global.tenant.hostname` | Per-tenant hostname, reserved for future routing | `""` |
+| `global.defaultStorageClass` | StorageClass for tenant PVCs (overrides the shared chart default) | `""` |
+| `openmrs-backend.db.url` | Full JDBC URL to the shared MariaDB | **required** |
+| `openmrs-backend.db.hostname` | Shared MariaDB host, used by the backend's `wait-for-it` preflight (`OMRS_DB_HOSTNAME`) | **required** |
+| `openmrs-backend.db.port` | Shared MariaDB port | `3306` |
+| `openmrs-backend.db.username` | Tenant DB user | **required** |
+| `openmrs-backend.db.password` | Tenant DB password | **required** |
+| `openmrs-backend.podLabels` | Extra labels for backend pods | `{}` |
+| `openmrs-frontend.enabled` | Deploy the frontend | `true` |
+| `openmrs-frontend.spaPath` | URL path the SPA is served from (`SPA_PATH`) | `"/openmrs/spa"` |
+| `openmrs-frontend.apiUrl` | SPA → backend API URL (`API_URL`) | `"/openmrs"` |
+| `openmrs-frontend.defaultLocale` | Default UI locale (`SPA_DEFAULT_LOCALE`) | `"en"` |
+| `openmrs-frontend.configUrls` | Distro config JSON URLs (`SPA_CONFIG_URLS`); omitted when empty | `""` |
+| `openmrs-frontend.replicaCount` | Frontend replicas | `1` |
+| `openmrs-frontend.podLabels` | Extra labels for frontend pods | `{}` |
+
+Images and versions are inherited from the shared charts (backend `3.7.x-no-demo`,
+frontend `3.7.x`); override via `openmrs-backend.image.*` / `openmrs-frontend.image.*`
+if needed. Clustering, autoscaling, and shared storage are shared-chart features and
+are covered in later phases.
+
 ### Alternative: install from Helm registry
 
       helm repo add openmrs https://openmrs.github.io/openmrs-contrib-cluster/
@@ -176,7 +302,7 @@ and a tenant chart can consume it. Infra deploy/scale settings live on the umbre
 | `openmrs-backend.db.hostname`                                    | External DB hostname. Only used when `global.mariadb.enabled=false`                                                     | `""` |
 | `openmrs-backend.db.database`                                    | OpenMRS database name for external (bring-your-own) databases. Empty falls back to `"openmrs"`. Ignored when `global.mariadb.enabled=true`, where the name always comes from `global.mariadb.auth.database` | `""` |
 | `openmrs-backend.db.username` / `.password`                      | Credentials for an external (bring-your-own) database. Used only when `global.mariadb.enabled=false`                   | `"openmrs"` / `"OpenMRS123"` |
-| `openmrs-backend.db.url`                                         | Full JDBC URL override for an external database (takes precedence over `db.hostname`). Ignored when `global.mariadb.enabled=true` | `""` |
+| `openmrs-backend.db.url`                                         | Full JDBC URL for an external database. **Requires `db.hostname` set too** — the URL is the JDBC connection, `db.hostname` feeds the image's startup preflight (which otherwise falls back to `localhost`). Ignored when `global.mariadb.enabled=true` | `""` |
 | `openmrs-backend.persistence.size`                               | Size of persistent volume to claim (for search index, attachments, etc.)                                               | `"8Gi"`                                                   |
 | `openmrs-backend.elasticsearch.enabled`                          | Wire the workload to use Elasticsearch (hibernate-search env/volumes). Does **not** deploy a cluster — see `elasticsearch.enabled` below | `false` |
 | `openmrs-backend.elasticsearch.uris` / `.username` / `.password` | External Elasticsearch connection details, used when `uris` is non-empty                                                | `""` |
@@ -427,9 +553,10 @@ dependencies and run helm upgrade.
 
 ### Releasing from Github Actions
 
-1. Bump `openmrs-backend`/`openmrs-frontend` `Chart.yaml` (and the umbrella's dependency
-   pin on them in `helm/openmrs/Chart.yaml`) in a regular commit first — the workflow
-   below doesn't touch these two, they version independently of the umbrella.
+1. Bump `openmrs-backend`/`openmrs-frontend`/`openmrs-tenant` `Chart.yaml` (and the
+   dependency pins on backend/frontend in **both** `helm/openmrs/Chart.yaml` and
+   `helm/openmrs-tenant/Chart.yaml`) in a regular commit first — the workflow below
+   doesn't touch these charts, they version independently of the umbrella.
 2. Go to the "Actions" tab in the GitHub repository.
 3. Select the "Release Charts" workflow from the left sidebar.
 4. Click the "Run workflow" dropdown button.

--- a/helm/openmrs-backend/Chart.yaml
+++ b/helm/openmrs-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0
+version: 2.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/openmrs-backend/templates/configmap.yaml
+++ b/helm/openmrs-backend/templates/configmap.yaml
@@ -22,6 +22,13 @@ data:
   {{- else }}
   {{- if .Values.db.url }}
   OMRS_DB_URL: {{ .Values.db.url | quote }}
+  {{- if regexMatch "^jdbc:mariadb" .Values.db.url }}
+  OMRS_DB: "mariadb"
+  {{- end }}
+  OMRS_DB_HOSTNAME: {{ required "openmrs-backend: db.hostname is required alongside db.url, since the image's startup preflight gates on OMRS_DB_HOSTNAME:OMRS_DB_PORT and falls back to localhost:3306" .Values.db.hostname | quote }}
+  {{- if .Values.db.port }}
+  OMRS_DB_PORT: {{ .Values.db.port | quote }}
+  {{- end }}
   {{- else }}
   OMRS_DB_NAME: {{ include "openmrs-backend.dbName" . | quote }}
   OMRS_DB_HOSTNAME: {{ .Values.db.hostname | quote }}

--- a/helm/openmrs-backend/templates/statefulset.yaml
+++ b/helm/openmrs-backend/templates/statefulset.yaml
@@ -21,6 +21,9 @@ spec:
         {{- end }}
       labels:
         {{- include "openmrs-backend.labels" . | nindent 8 }}
+        {{- with (dig "tenant" "name" "" (default dict .Values.global)) }}
+        app.kubernetes.io/tenant: {{ . | quote }}
+        {{- end }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -141,7 +144,9 @@ spec:
         name: data
       spec:
         accessModes: [ "ReadWriteOnce" ]
-        storageClassName: {{ .Values.global.defaultStorageClass | quote }}
+        {{- with .Values.global.defaultStorageClass }}
+        storageClassName: {{ . | quote }}
+        {{- end }}
         resources:
           requests:
             storage: {{ .Values.persistence.size | quote }}

--- a/helm/openmrs-backend/values.yaml
+++ b/helm/openmrs-backend/values.yaml
@@ -35,7 +35,9 @@ db:
   port: 3306
   database: ""        # External DB name, falls back to "openmrs". Ignored when
                       # global.mariadb.enabled=true (uses global.mariadb.auth.database instead).
-  url: ""             # Full JDBC URL override, takes precedence over hostname/port/database.
+  url: ""             # Full JDBC URL for an external database. Requires db.hostname
+                      # alongside it (the image's startup preflight gates on
+                      # OMRS_DB_HOSTNAME:OMRS_DB_PORT); db.database is ignored.
                       # Ignored when global.mariadb.enabled=true.
   username: openmrs
   password: OpenMRS123

--- a/helm/openmrs-frontend/Chart.yaml
+++ b/helm/openmrs-frontend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0
+version: 2.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/openmrs-frontend/templates/deployment.yaml
+++ b/helm/openmrs-frontend/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
         {{- end }}
       labels:
         {{- include "openmrs-frontend.labels" . | nindent 8 }}
+        {{- with (dig "tenant" "name" "" (default dict .Values.global)) }}
+        app.kubernetes.io/tenant: {{ . | quote }}
+        {{- end }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm/openmrs-tenant/.helmignore
+++ b/helm/openmrs-tenant/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# Build artifact
+/*.tgz

--- a/helm/openmrs-tenant/Chart.lock
+++ b/helm/openmrs-tenant/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: openmrs-backend
+  repository: file://../openmrs-backend
+  version: 2.1.0
+- name: openmrs-frontend
+  repository: file://../openmrs-frontend
+  version: 2.1.0
+digest: sha256:b749801ad09733643f1be9186e464fcd274dc5e17fa97e10e3fc16807cd90070
+generated: "2026-08-11T23:28:12.383856455+03:00"

--- a/helm/openmrs-tenant/Chart.yaml
+++ b/helm/openmrs-tenant/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: openmrs-tenant
+description: OpenMRS Tenant Helm chart — minimal backend+frontend for one tenant sharing existing infrastructure
+type: application
+version: 1.0.0
+appVersion: "3.7.x-no-demo"
+
+dependencies:
+  - name: openmrs-backend
+    version: 2.1.0
+    repository: "file://../openmrs-backend"
+    #repository: "oci://ghcr.io/openmrs"
+  - name: openmrs-frontend
+    version: 2.1.0
+    repository: "file://../openmrs-frontend"
+    #repository: "oci://ghcr.io/openmrs"
+    condition: openmrs-frontend.enabled

--- a/helm/openmrs-tenant/templates/NOTES.txt
+++ b/helm/openmrs-tenant/templates/NOTES.txt
@@ -1,0 +1,17 @@
+Congratulations! The OpenMRS Tenant has been successfully deployed!
+
+Tenant: {{ .Values.global.tenant.name }}
+Backend: {{ .Release.Name }}-openmrs-backend.{{ .Release.Namespace }}.svc.cluster.local:8080
+Frontend: {{ .Release.Name }}-openmrs-frontend.{{ .Release.Namespace }}.svc.cluster.local:80
+
+To verify the tenant label:
+  kubectl get pods -n {{ .Release.Namespace }} -L app.kubernetes.io/tenant
+
+To port-forward the backend API for local access:
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ .Release.Name }}-openmrs-backend 8080:8080
+
+The frontend can be port-forwarded too, but note the SPA UI is not fully usable
+this way yet: the app shell requests its assets under SPA_PATH ({{ (index .Values "openmrs-frontend").spaPath }}),
+which need a gateway rewrite to resolve, so they 404 over a plain port-forward
+(you get a blank page). Tenant HTTPRoute support lands under TRUNK-6654.
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ .Release.Name }}-openmrs-frontend 8081:80

--- a/helm/openmrs-tenant/templates/validate-db.yaml
+++ b/helm/openmrs-tenant/templates/validate-db.yaml
@@ -1,0 +1,12 @@
+{{- /*
+Fail fast if the tenant's shared-MariaDB connection isn't fully set. Left empty,
+the shared backend falls back to its own defaults (host "mariadb", db "openmrs"
+— the primary's) with blank creds, renders clean, then fails at runtime.
+*/}}
+{{- if not .Values.global.tenant.name -}}
+{{- fail "openmrs-tenant: global.tenant.name is required." -}}
+{{- end -}}
+{{- $db := (index .Values "openmrs-backend").db | default dict -}}
+{{- if or (not $db.url) (not $db.hostname) (not $db.username) (not $db.password) -}}
+{{- fail "openmrs-tenant: openmrs-backend.db.url, .hostname, .username and .password are all required. See the README's \"Deploy additional tenants\" section." -}}
+{{- end -}}

--- a/helm/openmrs-tenant/values.yaml
+++ b/helm/openmrs-tenant/values.yaml
@@ -1,0 +1,53 @@
+# Default values for openmrs-tenant.
+# A thin chart: the backend and frontend workloads come from the shared
+# openmrs-backend/openmrs-frontend charts, consumed as dependencies.
+# This chart only supplies the per-tenant configuration surface on top of them.
+
+global:
+  defaultStorageClass: ""
+  tenant:
+    name: ""
+    hostname: ""
+  mariadb:
+    enabled: false
+
+openmrs-backend:
+  # Off until routing is wired in: the shared chart's route has no hostname and
+  # would collide on the shared gateway.
+  gateway:
+    enabled: false
+
+  # A tenant shares the primary cluster's MariaDB — external DB only, no
+  # bundled MariaDB.
+  db:
+    url: ""        # full JDBC URL to the shared MariaDB, e.g.
+                   # "jdbc:mariadb:loadbalance://mariadb:3306/<tenantdb>?autoReconnect=true&sessionVariables=default_storage_engine=InnoDB&useUnicode=true&characterEncoding=UTF-8&useMysqlMetadata=true"
+    # hostname/port feed the backend image's wait-for-it preflight (it gates on
+    # OMRS_DB_HOSTNAME:OMRS_DB_PORT, defaulting to localhost:3306), so they must
+    # point at the same shared MariaDB the JDBC URL connects to.
+    hostname: ""   # e.g. <primary-release>-mariadb.<primary-namespace>.svc.cluster.local
+    port: 3306
+    username: ""
+    password: ""
+
+  podLabels: {}
+
+openmrs-frontend:
+  enabled: true
+  # Off until routing is wired in
+  gateway:
+    enabled: false
+
+  # Per-tenant SPA configuration. spaPath drives the ConfigMap, the route
+  # match, and the root-redirect target, so a per-tenant path override stays
+  # consistent end to end.
+  spaPath: "/openmrs/spa"
+  apiUrl: "/openmrs"
+  defaultLocale: "en"
+  # Empty = no SPA_CONFIG_URLS config file. A tenant that needs a per-tenant
+  # config file sets this.
+  configUrls: ""
+
+  replicaCount: 1
+
+  podLabels: {}

--- a/helm/openmrs/Chart.lock
+++ b/helm/openmrs/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: openmrs-backend
   repository: file://../openmrs-backend
-  version: 2.0.0
+  version: 2.1.0
 - name: openmrs-frontend
   repository: file://../openmrs-frontend
-  version: 2.0.0
+  version: 2.1.0
 - name: seaweedfs
   repository: https://seaweedfs.github.io/seaweedfs/helm
   version: 4.31.0
@@ -20,5 +20,5 @@ dependencies:
 - name: eck-elasticsearch
   repository: https://helm.elastic.co
   version: 0.19.0
-digest: sha256:1cb0bc6d179b65dc2847fedb94082cfd74388613a642fbe0c1dff3d94afadd52
-generated: "2026-08-06T16:43:22.339359922+03:00"
+digest: sha256:99c6faf1491b107476ad9dfeed1d4fa7d5527aaac8b8d2c489f5cef96b3812ad
+generated: "2026-08-11T23:28:25.994782103+03:00"

--- a/helm/openmrs/Chart.yaml
+++ b/helm/openmrs/Chart.yaml
@@ -25,11 +25,11 @@ appVersion: "3.7.x"
 
 dependencies:
   - name: openmrs-backend
-    version: 2.0.0
+    version: 2.1.0
     repository: "file://../openmrs-backend"
     #repository: "oci://ghcr.io/openmrs"
   - name: openmrs-frontend
-    version: 2.0.0
+    version: 2.1.0
     repository: "file://../openmrs-frontend"
     #repository: "oci://ghcr.io/openmrs"
     condition: openmrs-frontend.enabled


### PR DESCRIPTION
## Summary
Adds `helm/openmrs-tenant`, a chart that deploys an isolated OpenMRS tenant (backend + frontend) sharing the primary cluster's infrastructure.

Following #28 which made `openmrs-backend` / `openmrs-frontend` infra-free, reusable charts, this is a thin umbrella: it depends on those two charts and supplies only the per-tenant configuration. It does not fork or re-declare any backend/frontend templates, so tenants inherit the reviewed shared-chart behaviour with no drift.

## What a tenant provides
`openmrs-backend.db.url` / `.hostname` / `.username `/ `.password` — connection to the shared MariaDB (per-tenant database + user)
`openmrs-frontend.spaPath` / `.apiUrl` / `.defaultLocale` / `.configUrls` — SPA config `app.kubernetes.io/tenant` pod label via podLabels
Each tenant is a separate Helm release in its own namespace. The chart fails fast if the DB connection isn't fully configured.


Supersedes the earlier standalone-fork PR (#19 ), which duplicated the backend/frontend templates; #28 enabled the cleaner subchart structure.

I am going to do database bootstrapping and gateway routing for the tenants once this gets in after review [sprint](https://openmrs.atlassian.net/browse/TRUNK-6483).

JIRA: https://openmrs.atlassian.net/browse/TRUNK-6652