### PR TITLE
TRUNK-6653: Add automated DB provisioning and render-time guards to openmrs-tenant chart.

### DIFF
--- a/.github/workflows/helm-build.yaml
+++ b/.github/workflows/helm-build.yaml
@@ -135,7 +135,7 @@ jobs:
           TENANT_VALUES="--set global.tenant.name=tenant1 \
             --set openmrs-backend.db.url=jdbc:mariadb:loadbalance://mariadb.example.svc.cluster.local:3306/openmrs_tenant1?autoReconnect=true&sessionVariables=default_storage_engine=InnoDB&useUnicode=true&characterEncoding=UTF-8&useMysqlMetadata=true \
             --set openmrs-backend.db.hostname=mariadb.example.svc.cluster.local \
-            --set openmrs-backend.db.username=ci_user \
+            --set openmrs-backend.db.username=openmrs_tenant1_user \
             --set openmrs-backend.db.password=ci-pass"
           helm lint helm/openmrs-tenant $TENANT_VALUES
           helm template tenant1 helm/openmrs-tenant $TENANT_VALUES > /tmp/tenant.yaml
@@ -144,19 +144,64 @@ jobs:
           grep -q 'OMRS_DB_URL: "jdbc:mariadb:loadbalance://mariadb.example.svc.cluster.local:3306/openmrs_tenant1?autoReconnect=true&sessionVariables=default_storage_engine=InnoDB&useUnicode=true&characterEncoding=UTF-8&useMysqlMetadata=true"' /tmp/tenant.yaml
           grep -q 'OMRS_DB_HOSTNAME: "mariadb.example.svc.cluster.local"' /tmp/tenant.yaml
           grep -q 'SPA_PATH: "/openmrs/spa"' /tmp/tenant.yaml
-          [ "$(grep -c 'app.kubernetes.io/tenant: "tenant1"' /tmp/tenant.yaml)" -eq 2 ]
+          # Backend and frontend pod templates (at least) carry the tenant label.
+          [ "$(grep -c 'app.kubernetes.io/tenant: "tenant1"' /tmp/tenant.yaml)" -ge 6 ]
           if grep -q 'storageClassName: ""' /tmp/tenant.yaml; then
             echo "empty storageClassName means no-class (PVC stays Pending); it must be omitted"; exit 1
           fi
-          # Phase-1 invariant: tenant routing is deferred to Phase 3 (TRUNK-6654), so the
-          # shared charts' HTTPRoutes are disabled by default — a host-less route would
-          # collide with the primary and other tenants on the shared gateway.
+          # Phase-1 invariant: HTTPRoutes stay off (host-less routes would collide
+          # on the shared gateway) until Phase 3 (TRUNK-6654).
           if grep -q 'kind: HTTPRoute' /tmp/tenant.yaml; then
             echo "expected NO HTTPRoutes in the default tenant render (gateway must stay off until Phase 3)"; exit 1
           fi
-          # DB connection is required: a tenant without db.url/hostname/username/password
-          # must fail to render, not silently fall back to the shared backend's
-          # primary-DB defaults (host "mariadb"/db "openmrs").
+          # Phase 2: operator Database/User/Grant CRs + credential Secret render,
+          # DB defaults to openmrs_<tenant>.
+          grep -q 'kind: Database' /tmp/tenant.yaml
+          grep -q 'kind: User' /tmp/tenant.yaml
+          grep -q 'kind: Grant' /tmp/tenant.yaml
+          grep -q 'name: tenant1-db-credentials' /tmp/tenant.yaml
+          grep -q 'k8s.mariadb.com/watch: ""' /tmp/tenant.yaml
+          grep -q 'mariaDbRef:' /tmp/tenant.yaml
+          grep -q 'name: "openmrs-mariadb"' /tmp/tenant.yaml
+          grep -q 'namespace: "openmrs"' /tmp/tenant.yaml
+          grep -q 'name: "openmrs_tenant1"' /tmp/tenant.yaml
+          grep -q 'maxUserConnections: 20' /tmp/tenant.yaml
+          [ "$(grep -c 'cleanupPolicy: "Skip"' /tmp/tenant.yaml)" -eq 3 ]
+          grep -q 'characterSet: utf8mb4' /tmp/tenant.yaml
+          grep -q 'collate: utf8mb4_general_ci' /tmp/tenant.yaml
+          # Hyphenated tenants normalize to '_' in the DB name (JDBC URL convention).
+          helm template east-coast helm/openmrs-tenant \
+            --set global.tenant.name=east-coast \
+            --set openmrs-backend.db.url=jdbc:mariadb:loadbalance://mariadb.example:3306/openmrs_east_coast \
+            --set openmrs-backend.db.hostname=mariadb.example \
+            --set openmrs-backend.db.username=openmrs_east_coast_user \
+            --set openmrs-backend.db.password=ec-pass > /tmp/tenant-hyphen.yaml
+          grep -q 'name: "openmrs_east_coast"' /tmp/tenant-hyphen.yaml
+          # Grant database must escape _ (SQL LIKE wildcard) to prevent cross-tenant access.
+          # The YAML file contains double backslashes (\\_) because | quote escapes \.
+          grep -q 'database: "openmrs\\\\_east\\\\_coast"' /tmp/tenant-hyphen.yaml
+          # All-digit tenant name: toString prevents int64 render errors.
+          helm template num1 helm/openmrs-tenant $TENANT_VALUES \
+            --set global.tenant.name=12345 \
+            --set openmrs-backend.db.username=openmrs_12345_user \
+            --set openmrs-backend.db.url=jdbc:mariadb:loadbalance://mariadb.example:3306/openmrs_12345 > /tmp/tenant-digit.yaml
+          grep -q 'name: "openmrs_12345"' /tmp/tenant-digit.yaml
+          grep -q 'app.kubernetes.io/tenant: "12345"' /tmp/tenant-digit.yaml
+          # dbBootstrap.database override: custom name must appear in CRs and match the URL.
+          helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+            --set dbBootstrap.database=openmrs_tenant1_custom \
+            --set "openmrs-backend.db.url=jdbc:mariadb:loadbalance://mariadb.example.svc.cluster.local:3306/openmrs_tenant1_custom?autoReconnect=true" > /tmp/tenant-override.yaml
+          grep -q 'name: "openmrs_tenant1_custom"' /tmp/tenant-override.yaml
+          # Drift guard: override must still match the URL's database.
+          if err=$(helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+              --set dbBootstrap.database=openmrs_tenant1_custom 2>&1); then
+            echo "expected the guard to reject a dbBootstrap.database override that differs from the URL's database"; exit 1
+          fi
+          grep -qF 'openmrs-tenant: openmrs-backend.db.url must target the same database' <<<"$err"
+          # A '/' inside the JDBC properties must not be read as the database segment.
+          helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+            --set "openmrs-backend.db.url=jdbc:mariadb:loadbalance://mariadb.example.svc.cluster.local:3306/openmrs_tenant1?useSsl=true&serverSslCert=/etc/ssl/certs/mariadb-ca.pem" > /dev/null
+          # Without these the backend silently falls back to the primary DB defaults.
           if err=$(helm template tenant1 helm/openmrs-tenant --set global.tenant.name=tenant1 2>&1); then
             echo "expected the db guard to reject a tenant with no database configured"; exit 1
           fi
@@ -165,6 +210,102 @@ jobs:
             echo "expected the guard to reject a tenant with no global.tenant.name"; exit 1
           fi
           grep -qF 'openmrs-tenant: global.tenant.name is required' <<<"$err"
+          # Tenant name must not contain _ — both - and _ normalize to _, so
+          # east-coast and east_coast would collide on the same MariaDB account.
+          if err=$(helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+              --set global.tenant.name=east_coast 2>&1); then
+            echo "expected the guard to reject a tenant name containing underscores"; exit 1
+          fi
+          grep -qF 'global.tenant.name must not contain underscores' <<<"$err"
+          # Tenant-scoping guard: username must be exactly openmrs_<tenant>_user.
+          if err=$(helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+              --set openmrs-backend.db.username=openmrs 2>&1); then
+            echo "expected the guard to reject a username that is not exactly openmrs_<tenant>_user"; exit 1
+          fi
+          grep -qF 'openmrs-backend.db.username' <<<"$err"
+          # A tenant whose name is a prefix of another's must not reach that tenant's account.
+          if err=$(helm template east helm/openmrs-tenant \
+              --set global.tenant.name=east \
+              --set openmrs-backend.db.url=jdbc:mariadb:loadbalance://mariadb.example:3306/openmrs_east \
+              --set openmrs-backend.db.hostname=mariadb.example \
+              --set openmrs-backend.db.username=openmrs_east_coast_user \
+              --set openmrs-backend.db.password=ec-pass 2>&1); then
+            echo "expected the guard to reject another tenant's user"; exit 1
+          fi
+          grep -qF 'must be exactly openmrs_east_user' <<<"$err"
+          # Tenant-scoping guard: database must contain the tenant name. The URL
+          # agrees with the override here, so only the tenant-scoping guard can
+          # be what rejects it.
+          if err=$(helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+              --set dbBootstrap.database=openmrs \
+              --set "openmrs-backend.db.url=jdbc:mariadb:loadbalance://mariadb.example.svc.cluster.local:3306/openmrs?autoReconnect=true" 2>&1); then
+            echo "expected the guard to reject a database name that does not contain the tenant name"; exit 1
+          fi
+          grep -qF 'dbBootstrap.database (openmrs) must contain the tenant name' <<<"$err"
+          # dbBootstrap disabled → no CRs/Secret leak.
+          helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+            --set dbBootstrap.enabled=false > /tmp/tenant-manual.yaml
+          if grep -q 'db-bootstrap' /tmp/tenant-manual.yaml; then
+            echo "expected NO dbBootstrap resources when disabled"; exit 1
+          fi
+          # No imperative bootstrap: no Job, no rootPassword, no SQL or bash
+          # interpolation reaching the database.
+          if grep -qE 'kind: Job|IDENTIFIED BY|CREATE DATABASE|rootPassword|db-bootstrap-job' /tmp/tenant.yaml; then
+            echo "expected NO imperative bootstrap (Job/SQL/rootPassword) in the operator-CRD render"; exit 1
+          fi
+          # Operator CWE-89 (26.6.0): ' and \ in CR-built SQL fields fail render loudly.
+          if err=$(helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+              --set "openmrs-backend.db.password=O'Brien\$(id)" 2>&1); then
+            echo "expected the dbBootstrap guard to reject a password with a single quote"; exit 1
+          fi
+          grep -qF 'openmrs-backend.db.password must not contain single quotes or backslashes' <<<"$err"
+          if err=$(helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+              --set 'openmrs-backend.db.password=C:\\windows' 2>&1); then
+            echo "expected the dbBootstrap guard to reject a password with a backslash"; exit 1
+          fi
+          grep -qF 'openmrs-backend.db.password must not contain single quotes or backslashes' <<<"$err"
+          if err=$(helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+              --set "openmrs-backend.db.username=openmrs_tenant1_user'" 2>&1); then
+            echo "expected the dbBootstrap guard to reject a username with a single quote"; exit 1
+          fi
+          grep -qF 'openmrs-backend.db.username must not contain single quotes or backslashes' <<<"$err"
+          if err=$(helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+              --set 'openmrs-backend.db.username=openmrs_tenant1\\user' 2>&1); then
+            echo "expected the dbBootstrap guard to reject a username with a backslash"; exit 1
+          fi
+          grep -qF 'openmrs-backend.db.username must not contain single quotes or backslashes' <<<"$err"
+          if err=$(helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+              --set "dbBootstrap.database=openmrs_tenant1't" 2>&1); then
+            echo "expected the guard to reject a database name with a single quote"; exit 1
+          fi
+          grep -qF 'single quotes, backslashes or backticks' <<<"$err"
+          if err=$(helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+              --set "dbBootstrap.database=openmrs_tenant1\`db" 2>&1); then
+            echo "expected the dbBootstrap guard to reject a database name with a backtick"; exit 1
+          fi
+          grep -qF 'single quotes, backslashes or backticks' <<<"$err"
+          if err=$(helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+              --set 'dbBootstrap.database=openmrs_tenant1\\db' 2>&1); then
+            echo "expected the guard to reject a database name with a backslash"; exit 1
+          fi
+          grep -qF 'single quotes, backslashes or backticks' <<<"$err"
+          # The URL's database segment must match the provisioned database — they are the same DB.
+          if err=$(helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+              --set "openmrs-backend.db.url=jdbc:mariadb:loadbalance://mariadb.example.svc.cluster.local:3306/other_db?autoReconnect=true" 2>&1); then
+            echo "expected the guard to reject a db.url whose database differs from dbBootstrap's"; exit 1
+          fi
+          grep -qF 'openmrs-tenant: openmrs-backend.db.url must target the same database' <<<"$err"
+          # Shell metachars without ' or \ still render.
+          helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+            --set 'openmrs-backend.db.password=O$Brien$(id)' > /tmp/tenant-inject.yaml
+          grep -qF 'password: "O$Brien$(id)"' /tmp/tenant-inject.yaml
+          if grep -qE 'IDENTIFIED BY|CREATE DATABASE|DB_PASS=|mariadb -u' /tmp/tenant-inject.yaml; then
+            echo "expected no shell/SQL interpolation surface in the operator-CRD render"; exit 1
+          fi
+          # All-digit password: quote handles int64 without toString.
+          helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+            --set 'openmrs-backend.db.password=12345' > /tmp/tenant-digit-pw.yaml
+          grep -qF 'password: "12345"' /tmp/tenant-digit-pw.yaml
           # Forward check (Phase 3): when routing IS enabled, the per-tenant spaPath still
           # reaches the route match and the redirect target, not just the ConfigMap.
           helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \

--- a/README.md
+++ b/README.md
@@ -110,16 +110,28 @@ configuration on top of them. Each tenant is a separate Helm release in its own 
 
 - Primary OpenMRS stack deployed and running (steps 1–4 above)
 - MariaDB accessible from tenant namespace (default DNS: `<primary-release>-mariadb.<primary-namespace>.svc.cluster.local`, e.g. `openmrs-mariadb.openmrs.svc.cluster.local`)
-- A database and user created for the tenant:
+- The **MariaDB operator** running **cluster-wide** (installed automatically by step 3's `openmrs-operator` chart; it watches all namespaces and reconciles the `Database` / `User` / `Grant` CRs below)
 
-```bash
-kubectl exec -n openmrs svc/openmrs-mariadb -- mysql -u root -pRoot123 -e "
-  CREATE DATABASE IF NOT EXISTS openmrs_<tenant> CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
-  CREATE USER IF NOT EXISTS '<tenant>_user'@'%' IDENTIFIED BY '<password>';
-  GRANT ALL PRIVILEGES ON openmrs_<tenant>.* TO '<tenant>_user'@'%';
-  FLUSH PRIVILEGES;
-"
-```
+The tenant's database and user are **created automatically**: the tenant chart renders the
+MariaDB operator's `Database` / `User` / `Grant` custom resources (in the tenant namespace,
+referencing the shared MariaDB via `mariaDbRef`). The operator turns them into
+`CREATE DATABASE` / `CREATE USER` / `GRANT` / `ALTER USER ... WITH MAX_USER_CONNECTIONS`
+declaratively — no imperative bootstrap Job runs, and the shared MariaDB's **root password
+never enters the tenant namespaces** (it stays inside the operator). Nothing to do by hand.
+
+> **Manual fallback:** with `--set dbBootstrap.enabled=false` the CRs are not
+> rendered and you must create the database and user yourself, e.g.:
+>
+> ```bash
+> # _ is a LIKE wildcard in GRANT; escape each _ as \_ and wrap in backticks.
+> # A quoted heredoc ('SQL') keeps backticks intact through the local shell.
+> kubectl exec -i -n openmrs svc/openmrs-mariadb -- mysql -u root -pRoot123 <<'SQL'
+>   CREATE DATABASE IF NOT EXISTS openmrs_east_coast CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+>   CREATE USER IF NOT EXISTS 'openmrs_east_coast_user'@'%' IDENTIFIED BY '<password>';
+>   GRANT ALL PRIVILEGES ON `openmrs\_east\_coast`.* TO 'openmrs_east_coast_user'@'%';
+>   FLUSH PRIVILEGES;
+> SQL
+> ```
 
 #### Install a tenant
 
@@ -140,9 +152,33 @@ helm install <tenant> helm/openmrs-tenant \
   --set openmrs-backend.db.url="jdbc:mariadb:loadbalance://<primary-release>-mariadb.<primary-namespace>.svc.cluster.local:3306/openmrs_<tenant>?autoReconnect=true&sessionVariables=default_storage_engine=InnoDB&useUnicode=true&characterEncoding=UTF-8&useMysqlMetadata=true" \
   --set openmrs-backend.db.hostname=<primary-release>-mariadb.<primary-namespace>.svc.cluster.local \
   --set openmrs-backend.db.port=3306 \
-  --set openmrs-backend.db.username=<tenant>_user \
-  --set openmrs-backend.db.password=<password>
+  --set openmrs-backend.db.username=openmrs_<tenant>_user \
+  --set openmrs-backend.db.password=<password> \
+  --set dbBootstrap.mariaDbRef.name=<primary-release>-mariadb \
+  --set dbBootstrap.mariaDbRef.namespace=<primary-namespace>
 ```
+
+> **Hyphenated tenant names:** the database defaults to `openmrs_<tenant>` with
+> any `-` in the tenant name replaced by `_` (JDBC URL convention). For example,
+> `global.tenant.name=east-coast` provisions `openmrs_east_coast`, so use
+> `.../openmrs_east_coast?...` in the JDBC URL, not `openmrs_east-coast`.
+> **Do not use `_` in tenant names** — both `-` and `_` normalize to `_`, so
+> `east-coast` and `east_coast` would collide on the same MariaDB account.
+
+The chart renders the MariaDB operator's `Database` / `User` / `Grant` CRs, which
+auto-provision the tenant database `openmrs_<tenant>` (override via
+`dbBootstrap.database`), the `openmrs_<tenant>_user` user, and its grants — the password is
+taken from `openmrs-backend.db.password` (matching the backend's own Secret). The CRs
+target the shared MariaDB via `dbBootstrap.mariaDbRef` (defaults to the primary chart's
+`openmrs-mariadb` CR in the `openmrs` namespace). Set `--set dbBootstrap.enabled=false`
+to skip bootstrapping and manage the database manually (see above).
+
+> **Known operator limitation:** the MariaDB operator (26.6.0, installed by
+> `openmrs-operator`) has an upstream SQL-injection advisory (CWE-89): it builds SQL
+> without escaping `'` in user/database names or passwords. The tenant chart rejects
+> `'`, `\` and `` ` `` (database name only) while `dbBootstrap.enabled=true` so the install fails
+> loudly instead of leaving a `User`/`Grant` CR stuck in `Error`. Change the value or
+> set `dbBootstrap.enabled=false` and create the user manually.
 
 Example for a tenant named `coast`:
 
@@ -154,7 +190,7 @@ helm install coast helm/openmrs-tenant \
   --set openmrs-backend.db.url="jdbc:mariadb:loadbalance://openmrs-mariadb.openmrs.svc.cluster.local:3306/openmrs_coast?autoReconnect=true&sessionVariables=default_storage_engine=InnoDB&useUnicode=true&characterEncoding=UTF-8&useMysqlMetadata=true" \
   --set openmrs-backend.db.hostname=openmrs-mariadb.openmrs.svc.cluster.local \
   --set openmrs-backend.db.port=3306 \
-  --set openmrs-backend.db.username=coast_user \
+  --set openmrs-backend.db.username=openmrs_coast_user \
   --set openmrs-backend.db.password=CoastPass123
 ```
 
@@ -175,6 +211,9 @@ kubectl get pods -n tenant-<tenant> -L app.kubernetes.io/tenant
 
 # Wait for ready
 kubectl wait --for=condition=ready pod -n tenant-<tenant> --all --timeout=600s
+
+# Check the MariaDB operator reconciled the tenant's CRs (Database/User/Grant ready)
+kubectl get database,user,grant -n tenant-<tenant>
 
 # Port-forward to backend (API)
 kubectl port-forward -n tenant-<tenant> svc/<tenant>-openmrs-backend 8080:8080
@@ -208,8 +247,14 @@ through. For the full shared-chart surface, see `helm/openmrs-backend/values.yam
 | `openmrs-backend.db.url` | Full JDBC URL to the shared MariaDB | **required** |
 | `openmrs-backend.db.hostname` | Shared MariaDB host, used by the backend's `wait-for-it` preflight (`OMRS_DB_HOSTNAME`) | **required** |
 | `openmrs-backend.db.port` | Shared MariaDB port | `3306` |
-| `openmrs-backend.db.username` | Tenant DB user | **required** |
+| `openmrs-backend.db.username` | Tenant DB user; must be exactly `openmrs_<tenant>_user` when `dbBootstrap.enabled=true` | **required** |
 | `openmrs-backend.db.password` | Tenant DB password | **required** |
+| `dbBootstrap.enabled` | Render the MariaDB operator's `Database` / `User` / `Grant` CRs that auto-provision the tenant's DB/user/grants on the shared MariaDB | `true` |
+| `dbBootstrap.mariaDbRef.name` | Name of the shared MariaDB CR to provision on | `openmrs-mariadb` |
+| `dbBootstrap.mariaDbRef.namespace` | Namespace of the shared MariaDB CR | `openmrs` |
+| `dbBootstrap.database` | Tenant database to provision on the shared MariaDB; default `openmrs_<tenant>` with hyphens normalized to underscores. Must contain `openmrs_<tenant>` and be the database in `openmrs-backend.db.url` — a mismatch or missing tenant name fails at render time | `openmrs_<tenant>` |
+| `dbBootstrap.maxUserConnections` | Per-tenant `MAX_USER_CONNECTIONS` limit on the shared MariaDB | `20` |
+| `dbBootstrap.cleanupPolicy` | Whether the DB/user are dropped on `helm uninstall`: `Skip` (safe default, keeps tenant data) or `Delete` | `Skip` |
 | `openmrs-backend.podLabels` | Extra labels for backend pods | `{}` |
 | `openmrs-frontend.enabled` | Deploy the frontend | `true` |
 | `openmrs-frontend.spaPath` | URL path the SPA is served from (`SPA_PATH`) | `"/openmrs/spa"` |

--- a/helm/openmrs-tenant/Chart.yaml
+++ b/helm/openmrs-tenant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openmrs-tenant
 description: OpenMRS Tenant Helm chart — minimal backend+frontend for one tenant sharing existing infrastructure
 type: application
-version: 1.0.0
+version: 2.0.0
 appVersion: "3.7.x-no-demo"
 
 dependencies:

--- a/helm/openmrs-tenant/templates/NOTES.txt
+++ b/helm/openmrs-tenant/templates/NOTES.txt
@@ -4,6 +4,19 @@ Tenant: {{ .Values.global.tenant.name }}
 Backend: {{ .Release.Name }}-openmrs-backend.{{ .Release.Namespace }}.svc.cluster.local:8080
 Frontend: {{ .Release.Name }}-openmrs-frontend.{{ .Release.Namespace }}.svc.cluster.local:80
 
+{{- if .Values.dbBootstrap.enabled }}
+Database: the tenant database and user are provisioned on the shared MariaDB
+via the MariaDB operator's Database / User / Grant custom resources (database
+"{{ include "openmrs-tenant.dbName" . }}", user "{{ (index .Values "openmrs-backend").db.username }}")
+— this requires the MariaDB operator (installed cluster-wide by the
+openmrs-operator chart) to be running. Verify with:
+  kubectl get database,user,grant -n {{ .Release.Namespace }}
+{{- else }}
+Database: dbBootstrap is disabled — the tenant database and user must already
+exist on the shared MariaDB (see the README's "Deploy additional tenants"
+section for the manual CREATE DATABASE / CREATE USER / GRANT SQL).
+{{- end }}
+
 To verify the tenant label:
   kubectl get pods -n {{ .Release.Namespace }} -L app.kubernetes.io/tenant
 

--- a/helm/openmrs-tenant/templates/_helpers.tpl
+++ b/helm/openmrs-tenant/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{- /*
+Standard labels for every K8s resource the tenant chart renders.
+Use in metadata.labels via: {{ include "openmrs-tenant.labels" . | nindent N }}
+*/}}
+{{- define "openmrs-tenant.labels" -}}
+app.kubernetes.io/name: openmrs-tenant
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/tenant: {{ .Values.global.tenant.name | quote }}
+{{- end }}
+
+{{- /*
+The tenant-scoped name openmrs_<tenant> (hyphens become underscores so it stays
+consistent with the openmrs_<tenant> JDBC URL convention). Both the default
+database name and the required DB username are built from it.
+*/}}
+{{- define "openmrs-tenant.normalizedTenant" -}}
+{{- printf "openmrs_%s" (.Values.global.tenant.name | toString | replace "-" "_") -}}
+{{- end }}
+
+{{- define "openmrs-tenant.dbName" -}}
+{{- .Values.dbBootstrap.database | default (include "openmrs-tenant.normalizedTenant" .) -}}
+{{- end }}

--- a/helm/openmrs-tenant/templates/db-bootstrap-database.yaml
+++ b/helm/openmrs-tenant/templates/db-bootstrap-database.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.dbBootstrap.enabled }}
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Database
+metadata:
+  name: {{ .Release.Name }}-db
+  labels:
+    {{- include "openmrs-tenant.labels" . | nindent 4 }}
+spec:
+  mariaDbRef:
+    name: {{ .Values.dbBootstrap.mariaDbRef.name | quote }}
+    namespace: {{ .Values.dbBootstrap.mariaDbRef.namespace | quote }}
+  name: {{ include "openmrs-tenant.dbName" . | quote }}
+  characterSet: utf8mb4
+  collate: utf8mb4_general_ci
+  cleanupPolicy: {{ .Values.dbBootstrap.cleanupPolicy | quote }}
+{{- end }}

--- a/helm/openmrs-tenant/templates/db-bootstrap-grant.yaml
+++ b/helm/openmrs-tenant/templates/db-bootstrap-grant.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.dbBootstrap.enabled }}
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Grant
+metadata:
+  name: {{ .Release.Name }}-grant
+  labels:
+    {{- include "openmrs-tenant.labels" . | nindent 4 }}
+spec:
+  mariaDbRef:
+    name: {{ .Values.dbBootstrap.mariaDbRef.name | quote }}
+    namespace: {{ .Values.dbBootstrap.mariaDbRef.namespace | quote }}
+  privileges:
+    - "ALL PRIVILEGES"
+  database: {{ include "openmrs-tenant.dbName" . | replace "_" "\\_" | quote }}
+  table: "*"
+  username: {{ (index .Values "openmrs-backend").db.username | quote }}
+  host: "%"
+  cleanupPolicy: {{ .Values.dbBootstrap.cleanupPolicy | quote }}
+{{- end }}

--- a/helm/openmrs-tenant/templates/db-bootstrap-secret.yaml
+++ b/helm/openmrs-tenant/templates/db-bootstrap-secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.dbBootstrap.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-db-credentials
+  labels:
+    {{- include "openmrs-tenant.labels" . | nindent 4 }}
+    k8s.mariadb.com/watch: ""
+type: Opaque
+stringData:
+  password: {{ (index .Values "openmrs-backend").db.password | quote }}
+{{- end }}

--- a/helm/openmrs-tenant/templates/db-bootstrap-user.yaml
+++ b/helm/openmrs-tenant/templates/db-bootstrap-user.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.dbBootstrap.enabled }}
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: User
+metadata:
+  name: {{ .Release.Name }}-user
+  labels:
+    {{- include "openmrs-tenant.labels" . | nindent 4 }}
+spec:
+  mariaDbRef:
+    name: {{ .Values.dbBootstrap.mariaDbRef.name | quote }}
+    namespace: {{ .Values.dbBootstrap.mariaDbRef.namespace | quote }}
+  name: {{ (index .Values "openmrs-backend").db.username | quote }}
+  passwordSecretKeyRef:
+    name: {{ .Release.Name }}-db-credentials
+    key: password
+  maxUserConnections: {{ .Values.dbBootstrap.maxUserConnections }}
+  host: "%"
+  cleanupPolicy: {{ .Values.dbBootstrap.cleanupPolicy | quote }}
+{{- end }}

--- a/helm/openmrs-tenant/templates/validate-db.yaml
+++ b/helm/openmrs-tenant/templates/validate-db.yaml
@@ -1,7 +1,6 @@
 {{- /*
-Fail fast if the tenant's shared-MariaDB connection isn't fully set. Left empty,
-the shared backend falls back to its own defaults (host "mariadb", db "openmrs"
-— the primary's) with blank creds, renders clean, then fails at runtime.
+Fail fast: without these the shared backend silently falls back to the primary's
+defaults (host "mariadb", db "openmrs") and only fails at runtime.
 */}}
 {{- if not .Values.global.tenant.name -}}
 {{- fail "openmrs-tenant: global.tenant.name is required." -}}
@@ -9,4 +8,37 @@ the shared backend falls back to its own defaults (host "mariadb", db "openmrs"
 {{- $db := (index .Values "openmrs-backend").db | default dict -}}
 {{- if or (not $db.url) (not $db.hostname) (not $db.username) (not $db.password) -}}
 {{- fail "openmrs-tenant: openmrs-backend.db.url, .hostname, .username and .password are all required. See the README's \"Deploy additional tenants\" section." -}}
+{{- end -}}
+{{- if .Values.dbBootstrap.enabled -}}
+{{- /*
+Why the guard: the MariaDB operator (26.6.0) builds SQL from CR fields without
+escaping ' or \, so those chars would leave a User/Grant CR stuck in Error.
+CRD presence can't be checked at render time (helm template runs without a
+cluster), so a missing operator is a documented README prerequisite.
+*/}}
+{{- if contains "_" (.Values.global.tenant.name | toString) -}}
+{{- fail "openmrs-tenant: global.tenant.name must not contain underscores while dbBootstrap.enabled=true — both - and _ normalize to _ in the database/user names, so tenants east-coast and east_coast would collide on the same MariaDB account. Use hyphens only or set dbBootstrap.enabled=false." -}}
+{{- end -}}
+{{- $dbName := include "openmrs-tenant.dbName" . -}}
+{{- $normalizedTenant := include "openmrs-tenant.normalizedTenant" . -}}
+{{- if not (contains $normalizedTenant $dbName) -}}
+{{- fail (printf "openmrs-tenant: dbBootstrap.database (%s) must contain the tenant name (%s). Use the default or set dbBootstrap.enabled=false." $dbName $normalizedTenant) -}}
+{{- end -}}
+{{- if or (contains "'" ($db.username | toString)) (contains "\\" ($db.username | toString)) -}}
+{{- fail "openmrs-tenant: openmrs-backend.db.username must not contain single quotes or backslashes while dbBootstrap.enabled=true — the MariaDB operator (upstream CWE-89, unfixed in 26.6.0) cannot safely provision such a user. Change the username or set dbBootstrap.enabled=false and create the user manually." -}}
+{{- end -}}
+{{- if ne ($db.username | toString) (printf "%s_user" $normalizedTenant) -}}
+{{- fail (printf "openmrs-tenant: openmrs-backend.db.username (%s) must be exactly %s_user. Anything looser lets one tenant take over another tenant's MariaDB account. Use the tenant-scoped name or set dbBootstrap.enabled=false." ($db.username | toString) $normalizedTenant) -}}
+{{- end -}}
+{{- if or (contains "'" ($db.password | toString)) (contains "\\" ($db.password | toString)) -}}
+{{- fail "openmrs-tenant: openmrs-backend.db.password must not contain single quotes or backslashes while dbBootstrap.enabled=true — the MariaDB operator (upstream CWE-89, unfixed in 26.6.0) cannot safely provision such a password. Change the password or set dbBootstrap.enabled=false and create the user manually." -}}
+{{- end -}}
+{{- if or (contains "'" $dbName) (contains "\\" $dbName) (contains "`" $dbName) -}}
+{{- fail "openmrs-tenant: the tenant database name (dbBootstrap.database, default openmrs_<tenant>) must not contain single quotes, backslashes or backticks while dbBootstrap.enabled=true — the MariaDB operator (upstream CWE-89, unfixed in 26.6.0) cannot safely provision such a database. Change the tenant name or dbBootstrap.database, or set dbBootstrap.enabled=false." -}}
+{{- end -}}
+{{- /* The URL's database segment must be the very database provisioned below — they are the same database. */ -}}
+{{- $urlDb := last (splitList "/" (first (splitList "?" $db.url))) -}}
+{{- if ne $urlDb $dbName -}}
+{{- fail (printf "openmrs-tenant: openmrs-backend.db.url must target the same database dbBootstrap provisions (%s); the URL's database segment is %s. Fix the JDBC URL or dbBootstrap.database." $dbName $urlDb) -}}
+{{- end -}}
 {{- end -}}

--- a/helm/openmrs-tenant/values.yaml
+++ b/helm/openmrs-tenant/values.yaml
@@ -11,6 +11,25 @@ global:
   mariadb:
     enabled: false
 
+# dbBootstrap provisions the tenant database/user/grants on the shared MariaDB
+# via the MariaDB operator's Database/User/Grant CRs — the root password never
+# leaves the operator. Disable for manual CREATE DATABASE/USER/GRANT.
+dbBootstrap:
+  enabled: true
+  # The shared MariaDB CR to provision on (from the primary openmrs chart).
+  mariaDbRef:
+    name: openmrs-mariadb
+    namespace: openmrs
+  # Database name override; default openmrs_<tenant> (hyphens → underscores).
+  # Must contain openmrs_<tenant> and be the database openmrs-backend.db.url
+  # connects to — the chart rejects either at render time.
+  database: ""
+  # Per-tenant connection limit on the shared MariaDB.
+  maxUserConnections: 20
+  # DB/user fate on helm uninstall: Skip keeps them, Delete drops them (the
+  # operator's own default is Delete — hence the safe Skip default).
+  cleanupPolicy: Skip
+
 openmrs-backend:
   # Off until routing is wired in: the shared chart's route has no hostname and
   # would collide on the shared gateway.
@@ -27,6 +46,8 @@ openmrs-backend:
     # point at the same shared MariaDB the JDBC URL connects to.
     hostname: ""   # e.g. <primary-release>-mariadb.<primary-namespace>.svc.cluster.local
     port: 3306
+    # Must be exactly openmrs_<tenant> + "_user" (hyphens → underscores) while
+    # dbBootstrap.enabled=true; the chart rejects anything else at render time.
     username: ""
     password: ""
 


### PR DESCRIPTION
## Summary
Automates tenant database/user/grant provisioning via MariaDB operator CRs (`dbBootstrap.enabled=true` by default), eliminating manual SQL steps. Adds render-time guards that reject unsafe credentials (CWE-89: '/\ in username, password, or database name) and catch `openmrs-backend.db.url` ↔ `dbBootstrap.database` mismatches before install. CI negative tests cover all four guards.

Key files: `db-bootstrap-{database,user,grant,secret}.yaml` (new CRs),` _helpers.tpl` (labels + dbName helper), `validate-db.yaml` (guards), `values.yaml` (dbBootstrap section), `README` and CI updates.

JIRA Ticket: https://openmrs.atlassian.net/browse/TRUNK-6653