### PR TITLE
TRUNK-6654: Add per-tenant host-scoped HTTPRoute routing via Gateway API.

### DIFF
--- a/.github/workflows/helm-build.yaml
+++ b/.github/workflows/helm-build.yaml
@@ -149,10 +149,10 @@ jobs:
           if grep -q 'storageClassName: ""' /tmp/tenant.yaml; then
             echo "empty storageClassName means no-class (PVC stays Pending); it must be omitted"; exit 1
           fi
-          # Phase-1 invariant: HTTPRoutes stay off (host-less routes would collide
-          # on the shared gateway) until Phase 3 (TRUNK-6654).
+          # Default render: HTTPRoutes stay off (gateway.enabled=false by default
+          # in the tenant chart, so hostless routes would collide on the shared gateway).
           if grep -q 'kind: HTTPRoute' /tmp/tenant.yaml; then
-            echo "expected NO HTTPRoutes in the default tenant render (gateway must stay off until Phase 3)"; exit 1
+            echo "expected NO HTTPRoutes in the default tenant render (gateway must stay off by default)"; exit 1
           fi
           # Phase 2: operator Database/User/Grant CRs + credential Secret render,
           # DB defaults to openmrs_<tenant>.
@@ -310,12 +310,156 @@ jobs:
           # reaches the route match and the redirect target, not just the ConfigMap.
           helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
             --set openmrs-backend.gateway.enabled=true \
+            --set "openmrs-backend.gateway.hostnames[0]=tenant1.example.com" \
             --set openmrs-frontend.gateway.enabled=true \
+            --set "openmrs-frontend.gateway.hostnames[0]=tenant1.example.com" \
             --set openmrs-frontend.spaPath=/tenant-a/spa \
-            --set openmrs-frontend.rootRedirect.enabled=true > /tmp/tenant-spa.yaml
-          grep -q 'SPA_PATH: "/tenant-a/spa"' /tmp/tenant-spa.yaml
-          grep -q 'value: /tenant-a/spa' /tmp/tenant-spa.yaml
-          grep -q 'replaceFullPath: /tenant-a/spa/home' /tmp/tenant-spa.yaml
+            --set openmrs-frontend.rootRedirect.enabled=true > /tmp/tenant-routing.yaml
+          grep -q 'SPA_PATH: "/tenant-a/spa"' /tmp/tenant-routing.yaml
+          grep -q 'value: /tenant-a/spa' /tmp/tenant-routing.yaml
+          grep -q 'replaceFullPath: /tenant-a/spa/home' /tmp/tenant-routing.yaml
+          grep -q 'tenant1.example.com' /tmp/tenant-routing.yaml
+          grep -q 'kind: HTTPRoute' /tmp/tenant-routing.yaml
           # Clustered infinispan still renders
           helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
             --set openmrs-backend.infinispan.clustered=true > /dev/null
+
+      - name: Validate routing guard (enabled without hostnames rejected)
+        run: |
+          TENANT_VALUES="--set global.tenant.name=tenant1 \
+            --set openmrs-backend.db.url=jdbc:mariadb:loadbalance://mariadb.example.svc.cluster.local:3306/openmrs_tenant1?autoReconnect=true&sessionVariables=default_storage_engine=InnoDB&useUnicode=true&characterEncoding=UTF-8&useMysqlMetadata=true \
+            --set openmrs-backend.db.hostname=mariadb.example.svc.cluster.local \
+            --set openmrs-backend.db.username=openmrs_tenant1_user \
+            --set openmrs-backend.db.password=ci-pass"
+          if err=$(helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+              --set openmrs-backend.gateway.enabled=true 2>&1); then
+            echo "expected the routing guard to reject backend gateway.enabled without hostnames"; exit 1
+          fi
+          grep -qF 'openmrs-backend.gateway.hostnames' <<<"$err"
+          if err=$(helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+              --set openmrs-frontend.gateway.enabled=true 2>&1); then
+            echo "expected the routing guard to reject frontend gateway.enabled without hostnames"; exit 1
+          fi
+          grep -qF 'openmrs-frontend.gateway.hostnames' <<<"$err"
+          # Frontend-only with default relative apiUrl must be rejected — the SPA
+          # would hit the primary backend's catch-all route.
+          if err=$(helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+              --set openmrs-frontend.gateway.enabled=true \
+              --set "openmrs-frontend.gateway.hostnames[0]=tenant1.example.com" 2>&1); then
+            echo "expected the guard to reject frontend-only routing with relative apiUrl"; exit 1
+          fi
+          grep -qF 'openmrs-backend.gateway does not route it' <<<"$err"
+          # Empty apiUrl is also relative (no scheme), must be rejected.
+          if err=$(helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+              --set openmrs-frontend.gateway.enabled=true \
+              --set "openmrs-frontend.gateway.hostnames[0]=tenant1.example.com" \
+              --set openmrs-frontend.apiUrl="" 2>&1); then
+            echo "expected the guard to reject empty apiUrl with frontend routing"; exit 1
+          fi
+          grep -qF 'openmrs-backend.gateway does not route it' <<<"$err"
+          # Dot-relative apiUrl must be rejected.
+          if err=$(helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+              --set openmrs-frontend.gateway.enabled=true \
+              --set "openmrs-frontend.gateway.hostnames[0]=tenant1.example.com" \
+              --set openmrs-frontend.apiUrl=./openmrs 2>&1); then
+            echo "expected the guard to reject dot-relative apiUrl with frontend routing"; exit 1
+          fi
+          grep -qF 'openmrs-backend.gateway does not route it' <<<"$err"
+          # Mismatched hostnames: frontend on cosat.example.com, backend on coast.example.com.
+          if err=$(helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+              --set openmrs-backend.gateway.enabled=true \
+              --set "openmrs-backend.gateway.hostnames[0]=coast.example.com" \
+              --set openmrs-frontend.gateway.enabled=true \
+              --set "openmrs-frontend.gateway.hostnames[0]=cosat.example.com" 2>&1); then
+            echo "expected the guard to reject mismatched hostnames"; exit 1
+          fi
+          grep -qF 'cosat.example.com serves the tenant SPA' <<<"$err"
+          # Backend-only (API-only tenant) must still render.
+          # NOTE: on this host, /openmrs/spa falls through to the primary's catch-all
+          # route — Traefik's priority math gives the hostless route precedence over
+          # the tenant's backend-only route for the SPA path. This is expected: an
+          # API-only tenant has no frontend to serve.
+          helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+            --set openmrs-backend.gateway.enabled=true \
+            --set "openmrs-backend.gateway.hostnames[0]=tenant1.example.com" > /dev/null
+          # Frontend with absolute apiUrl must bypass the hostname check.
+          helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+            --set openmrs-backend.gateway.enabled=true \
+            --set "openmrs-backend.gateway.hostnames[0]=tenant1.example.com" \
+            --set openmrs-frontend.gateway.enabled=true \
+            --set "openmrs-frontend.gateway.hostnames[0]=tenant1.example.com" \
+            --set openmrs-frontend.apiUrl=https://api.example.com > /dev/null
+          # Host-absolute apiUrl (//api.example.com) must also bypass the check.
+          helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+            --set openmrs-backend.gateway.enabled=true \
+            --set "openmrs-backend.gateway.hostnames[0]=tenant1.example.com" \
+            --set openmrs-frontend.gateway.enabled=true \
+            --set "openmrs-frontend.gateway.hostnames[0]=tenant1.example.com" \
+            --set openmrs-frontend.apiUrl=//api.example.com > /dev/null
+
+      - name: Validate primary render unchanged (no hostnames on routes)
+        run: |
+          helm template helm/openmrs --generate-name \
+            --set monitoring.enabled=false \
+            --set elasticsearch.enabled=false \
+            --set seaweedfs.enabled=false > /tmp/primary.yaml
+          grep -q 'kind: HTTPRoute' /tmp/primary.yaml
+          if grep -q 'coast.example.com\|nyanza.example.com' /tmp/primary.yaml; then
+            echo "primary render must not contain tenant hostnames"; exit 1
+          fi
+          # The primary backend/frontend routes must stay hostless (catch-all).
+          # The root-redirect route legitimately carries a hostname, so scope this
+          # to the two catch-all templates rather than the whole render.
+          # Capture output first so a helm error (e.g. renamed template) fails
+          # the step under bash -e instead of silently passing via grep on empty.
+          out=$(helm template helm/openmrs --generate-name \
+              --set monitoring.enabled=false \
+              --set elasticsearch.enabled=false \
+              --set seaweedfs.enabled=false \
+              --show-only charts/openmrs-backend/templates/httproute.yaml \
+              --show-only charts/openmrs-frontend/templates/httproute.yaml)
+          if grep -q 'hostnames:' <<<"$out"; then
+            echo "primary HTTPRoutes must not have hostnames (catch-all)"; exit 1
+          fi
+
+      - name: Validate root-redirect hostname fallback and merge
+        run: |
+          TENANT_VALUES="--set global.tenant.name=tenant1 \
+            --set openmrs-backend.db.url=jdbc:mariadb:loadbalance://mariadb.example.svc.cluster.local:3306/openmrs_tenant1?autoReconnect=true&sessionVariables=default_storage_engine=InnoDB&useUnicode=true&characterEncoding=UTF-8&useMysqlMetadata=true \
+            --set openmrs-backend.db.hostname=mariadb.example.svc.cluster.local \
+            --set openmrs-backend.db.username=openmrs_tenant1_user \
+            --set openmrs-backend.db.password=ci-pass"
+          # Case 1: rootRedirect.hostnames empty, gateway.hostnames set → fallback
+          helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+            --set openmrs-backend.gateway.enabled=true \
+            --set "openmrs-backend.gateway.hostnames[0]=tenant1.example.com" \
+            --set openmrs-frontend.gateway.enabled=true \
+            --set "openmrs-frontend.gateway.hostnames[0]=tenant1.example.com" \
+            --set openmrs-frontend.rootRedirect.enabled=true > /tmp/tenant-fallback.yaml
+          # root-redirect-httproute should inherit gateway.hostnames
+          grep -A20 'root-redirect' /tmp/tenant-fallback.yaml | grep -q 'tenant1.example.com'
+          # ...and nothing else: if the shared frontend chart ever defaults
+          # rootRedirect.hostnames back to [localhost], every tenant's route would
+          # claim localhost too and the check above would still pass.
+          if grep -A20 'root-redirect' /tmp/tenant-fallback.yaml | grep -q 'localhost'; then
+            echo "tenant root-redirect must not inherit a localhost default from the shared chart"; exit 1
+          fi
+          # Case 2: both rootRedirect.hostnames and gateway.hostnames set → merge (dedup)
+          helm template tenant1 helm/openmrs-tenant $TENANT_VALUES \
+            --set openmrs-backend.gateway.enabled=true \
+            --set "openmrs-backend.gateway.hostnames[0]=tenant1.example.com" \
+            --set openmrs-frontend.gateway.enabled=true \
+            --set "openmrs-frontend.gateway.hostnames[0]=tenant1.example.com" \
+            --set openmrs-frontend.rootRedirect.enabled=true \
+            --set "openmrs-frontend.rootRedirect.hostnames[0]=root.example.com" > /tmp/tenant-merge.yaml
+          # root-redirect should have both hostnames (deduplicated)
+          grep -A20 'root-redirect' /tmp/tenant-merge.yaml | grep -q 'root.example.com'
+          grep -A20 'root-redirect' /tmp/tenant-merge.yaml | grep -q 'tenant1.example.com'
+          # Case 3: NOTES.txt uses actual spaPath, not hardcoded /openmrs/spa
+          # helm template does not render NOTES.txt; verify the template directly.
+          grep -q '{{ index $.Values "openmrs-frontend" "spaPath" }}/home' helm/openmrs-tenant/templates/NOTES.txt
+          if grep -q '/openmrs/spa/home' helm/openmrs-tenant/templates/NOTES.txt; then
+            echo "NOTES.txt must not hardcode /openmrs/spa when spaPath is used"; exit 1
+          fi
+
+

--- a/README.md
+++ b/README.md
@@ -191,7 +191,11 @@ helm install coast helm/openmrs-tenant \
   --set openmrs-backend.db.hostname=openmrs-mariadb.openmrs.svc.cluster.local \
   --set openmrs-backend.db.port=3306 \
   --set openmrs-backend.db.username=openmrs_coast_user \
-  --set openmrs-backend.db.password=CoastPass123
+  --set openmrs-backend.db.password=CoastPass123 \
+  --set openmrs-backend.gateway.enabled=true \
+  --set "openmrs-backend.gateway.hostnames[0]=coast.example.com" \
+  --set openmrs-frontend.gateway.enabled=true \
+  --set "openmrs-frontend.gateway.hostnames[0]=coast.example.com"
 ```
 
 > **Naming:** resources are named from the **release name** (the first argument to
@@ -215,23 +219,24 @@ kubectl wait --for=condition=ready pod -n tenant-<tenant> --all --timeout=600s
 # Check the MariaDB operator reconciled the tenant's CRs (Database/User/Grant ready)
 kubectl get database,user,grant -n tenant-<tenant>
 
-# Port-forward to backend (API)
-kubectl port-forward -n tenant-<tenant> svc/<tenant>-openmrs-backend 8080:8080
+# Point the tenant hostname at the gateway (local dev)
+echo "127.0.0.1 coast.example.com" | sudo tee -a /etc/hosts
 
-# Port-forward to frontend (SPA)
-kubectl port-forward -n tenant-<tenant> svc/<tenant>-openmrs-frontend 8081:80
+# Open the SPA in a browser (Traefik binds host port 8080 on the Kind cluster)
+# http://coast.example.com:8080/openmrs/spa/home
+
+# Port-forward to backend (API) for direct access
+kubectl port-forward -n tenant-<tenant> svc/<tenant>-openmrs-backend 8080:8080
 ```
 
-> **Note on routing:** tenant HTTPRoutes are disabled in this chart
-> (`openmrs-backend.gateway.enabled` and `openmrs-frontend.gateway.enabled` default to
-> `false`) — per-tenant routing is deferred to a later phase (TRUNK-6654), since the
-> shared charts' routes carry no hostname and would collide on the shared gateway.
-> Reach the backend API via `kubectl port-forward` as shown. The **frontend SPA UI is
-> not fully usable over port-forward** — the app shell requests its assets under
-> `SPA_PATH` (`/openmrs/spa`), which needs a gateway rewrite (stripping the prefix
-> before nginx) that port-forward cannot provide. Once tenant routing lands, each
-> tenant's frontend and backend will sit behind a per-tenant hostname
-> (e.g. `<tenant>.example.com`), like the primary OpenMRS stack.
+> **Note on routing:** tenant HTTPRoutes are disabled by default (`gateway.enabled=false`).
+> To enable host-based routing, set `openmrs-backend.gateway.enabled=true` and
+> `openmrs-backend.gateway.hostnames` (and likewise for frontend). The shared charts'
+> routes emit hostnames only when `gateway.hostnames` is non-empty, so the primary
+> umbrella's hostless routes act as a catch-all while tenant routes match on specific
+> hostnames — no collisions. Each tenant's frontend and backend sit behind a per-tenant
+> hostname (e.g. `coast.example.com`), like the primary OpenMRS stack. Point that
+> hostname at the gateway (DNS, or an `/etc/hosts` entry) to reach the SPA.
 
 #### Tenant chart parameters
 
@@ -242,7 +247,6 @@ through. For the full shared-chart surface, see `helm/openmrs-backend/values.yam
 | Name | Description | Default |
 |------|-------------|---------|
 | `global.tenant.name` | Tenant identifier; sets the `app.kubernetes.io/tenant` label on backend/frontend pods | **required** |
-| `global.tenant.hostname` | Per-tenant hostname, reserved for future routing | `""` |
 | `global.defaultStorageClass` | StorageClass for tenant PVCs (overrides the shared chart default) | `""` |
 | `openmrs-backend.db.url` | Full JDBC URL to the shared MariaDB | **required** |
 | `openmrs-backend.db.hostname` | Shared MariaDB host, used by the backend's `wait-for-it` preflight (`OMRS_DB_HOSTNAME`) | **required** |
@@ -255,8 +259,12 @@ through. For the full shared-chart surface, see `helm/openmrs-backend/values.yam
 | `dbBootstrap.database` | Tenant database to provision on the shared MariaDB; default `openmrs_<tenant>` with hyphens normalized to underscores. Must contain `openmrs_<tenant>` and be the database in `openmrs-backend.db.url` — a mismatch or missing tenant name fails at render time | `openmrs_<tenant>` |
 | `dbBootstrap.maxUserConnections` | Per-tenant `MAX_USER_CONNECTIONS` limit on the shared MariaDB | `20` |
 | `dbBootstrap.cleanupPolicy` | Whether the DB/user are dropped on `helm uninstall`: `Skip` (safe default, keeps tenant data) or `Delete` | `Skip` |
+| `openmrs-backend.gateway.enabled` | Enable Gateway API HTTPRoute for the backend (requires `gateway.hostnames` set) | `false` |
+| `openmrs-backend.gateway.hostnames` | Hostnames for the backend HTTPRoute; must be non-empty when `gateway.enabled=true` | `[]` |
 | `openmrs-backend.podLabels` | Extra labels for backend pods | `{}` |
 | `openmrs-frontend.enabled` | Deploy the frontend | `true` |
+| `openmrs-frontend.gateway.enabled` | Enable Gateway API HTTPRoute for the frontend (requires `gateway.hostnames` set) | `false` |
+| `openmrs-frontend.gateway.hostnames` | Hostnames for the frontend HTTPRoute; must be non-empty when `gateway.enabled=true` | `[]` |
 | `openmrs-frontend.spaPath` | URL path the SPA is served from (`SPA_PATH`) | `"/openmrs/spa"` |
 | `openmrs-frontend.apiUrl` | SPA → backend API URL (`API_URL`) | `"/openmrs"` |
 | `openmrs-frontend.defaultLocale` | Default UI locale (`SPA_DEFAULT_LOCALE`) | `"en"` |

--- a/helm/kind-openmrs.yaml
+++ b/helm/kind-openmrs.yaml
@@ -44,6 +44,8 @@ openmrs-frontend:
       namespace: openmrs-system
   rootRedirect:
     enabled: true
+    hostnames:
+      - localhost
   image:
     repository: openmrs/openmrs-reference-application-3-frontend
     tag: 3.7.x

--- a/helm/openmrs-backend/Chart.yaml
+++ b/helm/openmrs-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0
+version: 2.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/openmrs-backend/templates/httproute.yaml
+++ b/helm/openmrs-backend/templates/httproute.yaml
@@ -10,6 +10,10 @@ spec:
   parentRefs:
     - name: {{ .Values.gateway.parentRefs.name }}
       namespace: {{ .Values.gateway.parentRefs.namespace }}
+  {{- with .Values.gateway.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   rules:
     - matches:
         - path:

--- a/helm/openmrs-backend/values.yaml
+++ b/helm/openmrs-backend/values.yaml
@@ -89,6 +89,7 @@ service:
 
 gateway:
   enabled: true
+  hostnames: []
   path: /openmrs/
   parentRefs:
     name: traefik-gateway

--- a/helm/openmrs-frontend/Chart.yaml
+++ b/helm/openmrs-frontend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0
+version: 2.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/openmrs-frontend/templates/NOTES.txt
+++ b/helm/openmrs-frontend/templates/NOTES.txt
@@ -8,4 +8,4 @@ NOTE: In case port-forward command does not work, make sure that OpenMRS Fronten
         kubectl -n {{ .Release.Namespace }} get svc
 
 The OpenMRS Frontend will be available at:
-  http://localhost:8080/openmrs/spa/home
+  http://localhost:8080{{ .Values.spaPath }}/home

--- a/helm/openmrs-frontend/templates/httproute.yaml
+++ b/helm/openmrs-frontend/templates/httproute.yaml
@@ -10,6 +10,10 @@ spec:
   parentRefs:
     - name: {{ .Values.gateway.parentRefs.name }}
       namespace: {{ .Values.gateway.parentRefs.namespace }}
+  {{- with .Values.gateway.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   rules:
     - matches:
         - path:

--- a/helm/openmrs-frontend/templates/root-redirect-httproute.yaml
+++ b/helm/openmrs-frontend/templates/root-redirect-httproute.yaml
@@ -10,9 +10,10 @@ spec:
   parentRefs:
     - name: {{ .Values.rootRedirect.parentRefs.name }}
       namespace: {{ .Values.rootRedirect.parentRefs.namespace }}
-  {{- with .Values.rootRedirect.hostnames }}
+  {{- $hosts := concat (.Values.rootRedirect.hostnames | default list) (.Values.gateway.hostnames | default list) | uniq }}
+  {{- if $hosts }}
   hostnames:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml $hosts | nindent 4 }}
   {{- end }}
   rules:
     - matches:

--- a/helm/openmrs-frontend/values.yaml
+++ b/helm/openmrs-frontend/values.yaml
@@ -52,6 +52,7 @@ service:
 
 gateway:
   enabled: true
+  hostnames: []
   path: ""       # defaults to spaPath if unset
   parentRefs:
     name: traefik-gateway
@@ -63,8 +64,7 @@ rootRedirect:
   parentRefs:
     name: traefik-gateway
     namespace: openmrs-system
-  hostnames:
-    - localhost
+  hostnames: []
 
 ingress:
   enabled: false

--- a/helm/openmrs-tenant/Chart.lock
+++ b/helm/openmrs-tenant/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: openmrs-backend
   repository: file://../openmrs-backend
-  version: 2.1.0
+  version: 2.2.0
 - name: openmrs-frontend
   repository: file://../openmrs-frontend
-  version: 2.1.0
-digest: sha256:b749801ad09733643f1be9186e464fcd274dc5e17fa97e10e3fc16807cd90070
-generated: "2026-08-11T23:28:12.383856455+03:00"
+  version: 2.2.0
+digest: sha256:e57ee0708c9766fbf6329dd432b4fdc8b36430c884b78394e11000772698188d
+generated: "2026-08-18T18:00:24.957410074+03:00"

--- a/helm/openmrs-tenant/Chart.yaml
+++ b/helm/openmrs-tenant/Chart.yaml
@@ -2,16 +2,16 @@ apiVersion: v2
 name: openmrs-tenant
 description: OpenMRS Tenant Helm chart — minimal backend+frontend for one tenant sharing existing infrastructure
 type: application
-version: 2.0.0
+version: 2.1.0
 appVersion: "3.7.x-no-demo"
 
 dependencies:
   - name: openmrs-backend
-    version: 2.1.0
+    version: 2.2.0
     repository: "file://../openmrs-backend"
     #repository: "oci://ghcr.io/openmrs"
   - name: openmrs-frontend
-    version: 2.1.0
+    version: 2.2.0
     repository: "file://../openmrs-frontend"
     #repository: "oci://ghcr.io/openmrs"
     condition: openmrs-frontend.enabled

--- a/helm/openmrs-tenant/templates/NOTES.txt
+++ b/helm/openmrs-tenant/templates/NOTES.txt
@@ -4,6 +4,14 @@ Tenant: {{ .Values.global.tenant.name }}
 Backend: {{ .Release.Name }}-openmrs-backend.{{ .Release.Namespace }}.svc.cluster.local:8080
 Frontend: {{ .Release.Name }}-openmrs-frontend.{{ .Release.Namespace }}.svc.cluster.local:80
 
+{{- if and (index .Values "openmrs-frontend" "gateway" "enabled") (index .Values "openmrs-frontend" "gateway" "hostnames") }}
+
+Tenant URL (via gateway, on the gateway's own port — :8080 on the Kind setup):
+{{- range (index .Values "openmrs-frontend" "gateway" "hostnames") }}
+  http://{{ . }}{{ index $.Values "openmrs-frontend" "spaPath" }}/home
+{{- end }}
+{{- end }}
+
 {{- if .Values.dbBootstrap.enabled }}
 Database: the tenant database and user are provisioned on the shared MariaDB
 via the MariaDB operator's Database / User / Grant custom resources (database
@@ -23,8 +31,9 @@ To verify the tenant label:
 To port-forward the backend API for local access:
   kubectl -n {{ .Release.Namespace }} port-forward svc/{{ .Release.Name }}-openmrs-backend 8080:8080
 
-The frontend can be port-forwarded too, but note the SPA UI is not fully usable
-this way yet: the app shell requests its assets under SPA_PATH ({{ (index .Values "openmrs-frontend").spaPath }}),
-which need a gateway rewrite to resolve, so they 404 over a plain port-forward
-(you get a blank page). Tenant HTTPRoute support lands under TRUNK-6654.
-  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ .Release.Name }}-openmrs-frontend 8081:80
+{{- if and (index .Values "openmrs-frontend" "gateway" "enabled") (index .Values "openmrs-frontend" "gateway" "hostnames") }}
+
+To access the SPA, point the tenant hostname at the gateway first:
+  echo "127.0.0.1 {{ (index .Values "openmrs-frontend" "gateway" "hostnames") | first }}" | sudo tee -a /etc/hosts
+Then open the tenant URL above in a browser.
+{{- end }}

--- a/helm/openmrs-tenant/templates/validate.yaml
+++ b/helm/openmrs-tenant/templates/validate.yaml
@@ -42,3 +42,25 @@ cluster), so a missing operator is a documented README prerequisite.
 {{- fail (printf "openmrs-tenant: openmrs-backend.db.url must target the same database dbBootstrap provisions (%s); the URL's database segment is %s. Fix the JDBC URL or dbBootstrap.database." $dbName $urlDb) -}}
 {{- end -}}
 {{- end -}}
+{{- /* Phase 3: routing guard — host-scoped HTTPRoutes must not collide. */ -}}
+{{- $beGw := (index .Values "openmrs-backend").gateway | default dict -}}
+{{- $feGw := (index .Values "openmrs-frontend").gateway | default dict -}}
+{{- if and (dig "enabled" false $beGw) (not (dig "hostnames" nil $beGw)) -}}
+{{- fail "openmrs-tenant: openmrs-backend.gateway.enabled=true requires openmrs-backend.gateway.hostnames to be set — a hostless HTTPRoute would collide on the shared gateway." -}}
+{{- end -}}
+{{- if and (dig "enabled" false $feGw) (not (dig "hostnames" nil $feGw)) -}}
+{{- fail "openmrs-tenant: openmrs-frontend.gateway.enabled=true requires openmrs-frontend.gateway.hostnames to be set — a hostless HTTPRoute would collide on the shared gateway." -}}
+{{- end -}}
+{{- /* The SPA calls the API same-origin while apiUrl is a relative path, so every host that
+       serves the tenant SPA must also route /openmrs/ to this tenant's backend. Otherwise
+       those calls fall through the primary umbrella's hostless route to the primary DB. */ -}}
+{{- $apiUrl := (index .Values "openmrs-frontend").apiUrl | default "" -}}
+{{- $absoluteApi := or (hasPrefix "http://" $apiUrl) (hasPrefix "https://" $apiUrl) (hasPrefix "//" $apiUrl) -}}
+{{- if and (dig "enabled" false $feGw) (not $absoluteApi) -}}
+{{- $beHosts := ternary (dig "hostnames" list $beGw) list (dig "enabled" false $beGw) -}}
+{{- range $h := (dig "hostnames" list $feGw) -}}
+{{- if not (has $h $beHosts) -}}
+{{- fail (printf "openmrs-tenant: %s serves the tenant SPA but openmrs-backend.gateway does not route it, so the SPA's relative apiUrl (%s) would reach the primary backend instead. Add %s to openmrs-backend.gateway.hostnames with openmrs-backend.gateway.enabled=true, or set an absolute openmrs-frontend.apiUrl." $h $apiUrl $h) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm/openmrs-tenant/values.yaml
+++ b/helm/openmrs-tenant/values.yaml
@@ -7,7 +7,6 @@ global:
   defaultStorageClass: ""
   tenant:
     name: ""
-    hostname: ""
   mariadb:
     enabled: false
 
@@ -31,10 +30,10 @@ dbBootstrap:
   cleanupPolicy: Skip
 
 openmrs-backend:
-  # Off until routing is wired in: the shared chart's route has no hostname and
-  # would collide on the shared gateway.
+  # Off by default; set hostnames alongside enabled.
   gateway:
     enabled: false
+    hostnames: []
 
   # A tenant shares the primary cluster's MariaDB — external DB only, no
   # bundled MariaDB.
@@ -55,9 +54,10 @@ openmrs-backend:
 
 openmrs-frontend:
   enabled: true
-  # Off until routing is wired in
+  # Off by default; set hostnames alongside enabled.
   gateway:
     enabled: false
+    hostnames: []
 
   # Per-tenant SPA configuration. spaPath drives the ConfigMap, the route
   # match, and the root-redirect target, so a per-tenant path override stays

--- a/helm/openmrs/Chart.lock
+++ b/helm/openmrs/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: openmrs-backend
   repository: file://../openmrs-backend
-  version: 2.1.0
+  version: 2.2.0
 - name: openmrs-frontend
   repository: file://../openmrs-frontend
-  version: 2.1.0
+  version: 2.2.0
 - name: seaweedfs
   repository: https://seaweedfs.github.io/seaweedfs/helm
   version: 4.31.0
@@ -20,5 +20,5 @@ dependencies:
 - name: eck-elasticsearch
   repository: https://helm.elastic.co
   version: 0.19.0
-digest: sha256:99c6faf1491b107476ad9dfeed1d4fa7d5527aaac8b8d2c489f5cef96b3812ad
-generated: "2026-08-11T23:28:25.994782103+03:00"
+digest: sha256:b86f7f1dee8f7d7acb06dae19851b7548d856145cfd8d75e98254ea002a676eb
+generated: "2026-08-18T17:59:44.013927143+03:00"

--- a/helm/openmrs/Chart.yaml
+++ b/helm/openmrs/Chart.yaml
@@ -25,11 +25,11 @@ appVersion: "3.7.x"
 
 dependencies:
   - name: openmrs-backend
-    version: 2.1.0
+    version: 2.2.0
     repository: "file://../openmrs-backend"
     #repository: "oci://ghcr.io/openmrs"
   - name: openmrs-frontend
-    version: 2.1.0
+    version: 2.2.0
     repository: "file://../openmrs-frontend"
     #repository: "oci://ghcr.io/openmrs"
     condition: openmrs-frontend.enabled

--- a/helm/openmrs/values.yaml
+++ b/helm/openmrs/values.yaml
@@ -48,6 +48,9 @@ openmrs-backend:
 openmrs-frontend:
   enabled: true
   nameOverride: "frontend"
+  rootRedirect:
+    hostnames:
+      - localhost
 
 # Infra owned by the umbrella (primary deployment). The tenant chart
 # consumes the shared backend/frontend charts only and has none of this.


### PR DESCRIPTION
## Summary
Previously, all tenants and the primary stack shared the same hostless HTTPRoutes on the Traefik Gateway, meaning there was no way to route traffic to a specific tenant based on hostname and every request hit the primary catch-all. This PR adds `gateway.hostnames` to the shared backend and frontend charts so that tenant HTTPRoutes emit host-scoped hostname matches while the primary umbrella's routes remain hostless as a catch-all. A validation guard in the tenant chart prevents tenants from enabling routing without setting hostnames, which would collide on the shared gateway. The result is that `kampala.example.com/openmrs/spa` routes to the kampala tenant, `masaka.example.com/openmrs/spa` routes to masaka, and any unmatched host falls through to primary, all on a single shared Traefik Gateway with zero manual routing configuration.

JIRA TICKET: https://openmrs.atlassian.net/browse/TRUNK-6654